### PR TITLE
update drivers list

### DIFF
--- a/book/src/Drivers.md
+++ b/book/src/Drivers.md
@@ -6,22 +6,22 @@ The following are a set of CSI driver which can be used with Kubernetes:
 ### Sample Drivers
 Name | Status | More Information
 -----|--------|-------
-[NFS](https://github.com/kubernetes-csi/drivers/tree/master/pkg/nfs) | Sample | 
-[HostPath](https://github.com/kubernetes-csi/drivers/tree/master/pkg/hostpath) | v0.2.0 | Only use for a single node tests. See the [Example](Example.html) page for Kubernetes-specific instructions.
 [Flexvolume](https://github.com/kubernetes-csi/drivers/tree/master/pkg/flexadapter) | Sample |
+[HostPath](https://github.com/kubernetes-csi/drivers/tree/master/pkg/hostpath) | v0.2.0 | Only use for a single node tests. See the [Example](Example.html) page for Kubernetes-specific instructions.
 [Mock Driver](https://github.com/kubernetes-csi/drivers/mock) | v0.2.0 | A mock CSI plugin usable as a stand-alone binary or in code.
+[NFS](https://github.com/kubernetes-csi/drivers/tree/master/pkg/nfs) | Sample | 
 [VFS Driver](https://github.com/thecodeteam/csi-vfs) | Released | A CSI plugin that provides a virtual file system.
 
 ### Production Drivers
 Name | Status | More Information
 -----|--------|-------
-[Portworx](https://portworx.com/) | Alpha | CSI implementation is available [here](https://github.com/libopenstorage/openstorage/tree/master/csi) which can be used as an example also.
-[OpenSDS](https://www.opensds.io/) | Beta | For more information, please visit [releases](https://github.com/opensds/nbp/releases) and https://github.com/opensds/nbp/tree/master/csi
-[ScaleIO](https://github.com/thecodeteam/csi-scaleio)|v0.1.0|A Container Storage Interface (CSI) Storage Plugin for DellEMC ScaleIO
-[vSphere](https://github.com/thecodeteam/csi-vsphere)|v0.1.0|A Container Storage Interface (CSI) Storage Plug-in for VMware vSphere
-[RBD](https://github.com/ceph/ceph-csi)|v0.2.0|A Container Storage Interface (CSI) Storage RBD Plug-in for Ceph
 [Cinder](https://github.com/kubernetes/cloud-provider-openstack/tree/master/pkg/csi/cinder)|v0.2.0|A Container Storage Interface (CSI) Storage Plug-in for Cinder
 [GCE Persistent Disk](https://github.com/GoogleCloudPlatform/compute-persistent-disk-csi-driver)|Alpha|A Container Storage Interface (CSI) Storage Plugin for Google Compute Engine Persistent Disk
+[OpenSDS](https://www.opensds.io/) | Beta | For more information, please visit [releases](https://github.com/opensds/nbp/releases) and https://github.com/opensds/nbp/tree/master/csi
+[Portworx](https://portworx.com/) | Alpha | CSI implementation is available [here](https://github.com/libopenstorage/openstorage/tree/master/csi) which can be used as an example also.
+[RBD](https://github.com/ceph/ceph-csi)|v0.2.0|A Container Storage Interface (CSI) Storage RBD Plug-in for Ceph
+[ScaleIO](https://github.com/thecodeteam/csi-scaleio)|v0.1.0|A Container Storage Interface (CSI) Storage Plugin for DellEMC ScaleIO
+[vSphere](https://github.com/thecodeteam/csi-vsphere)|v0.1.0|A Container Storage Interface (CSI) Storage Plug-in for VMware vSphere
 
 ## Testing
 There are multiple ways to test your driver. Please see [Testing Drivers](Testing-Drivers.html) for more information.

--- a/book/src/Drivers.md
+++ b/book/src/Drivers.md
@@ -16,6 +16,7 @@ Name | Status | More Information
 Name | Status | More Information
 -----|--------|-------
 [Cinder](https://github.com/kubernetes/cloud-provider-openstack/tree/master/pkg/csi/cinder)|v0.2.0|A Container Storage Interface (CSI) Storage Plug-in for Cinder
+[DigitalOcean Block Storage](https://github.com/digitalocean/csi-digitalocean) | v0.0.1 (alpha) | A Container Storage Interface (CSI) Driver for DigitalOcean Block Storage
 [GCE Persistent Disk](https://github.com/GoogleCloudPlatform/compute-persistent-disk-csi-driver)|Alpha|A Container Storage Interface (CSI) Storage Plugin for Google Compute Engine Persistent Disk
 [OpenSDS](https://www.opensds.io/) | Beta | For more information, please visit [releases](https://github.com/opensds/nbp/releases) and https://github.com/opensds/nbp/tree/master/csi
 [Portworx](https://portworx.com/) | Alpha | CSI implementation is available [here](https://github.com/libopenstorage/openstorage/tree/master/csi) which can be used as an example also.

--- a/docs/Drivers.html
+++ b/docs/Drivers.html
@@ -136,6 +136,7 @@
 <a class="header" href="Drivers.html#production-drivers" id="production-drivers"><h3>Production Drivers</h3></a>
 <table><thead><tr><th>Name </th><th> Status </th><th> More Information</th></tr></thead><tbody>
 <tr><td><a href="https://github.com/kubernetes/cloud-provider-openstack/tree/master/pkg/csi/cinder">Cinder</a></td><td>v0.2.0</td><td>A Container Storage Interface (CSI) Storage Plug-in for Cinder</td></tr>
+<tr><td><a href="https://github.com/digitalocean/csi-digitalocean">DigitalOcean Block Storage</a> </td><td> v0.0.1 (alpha) </td><td> A Container Storage Interface (CSI) Driver for DigitalOcean Block Storage</td></tr>
 <tr><td><a href="https://github.com/GoogleCloudPlatform/compute-persistent-disk-csi-driver">GCE Persistent Disk</a></td><td>Alpha</td><td>A Container Storage Interface (CSI) Storage Plugin for Google Compute Engine Persistent Disk</td></tr>
 <tr><td><a href="https://www.opensds.io/">OpenSDS</a> </td><td> Beta </td><td> For more information, please visit <a href="https://github.com/opensds/nbp/releases">releases</a> and https://github.com/opensds/nbp/tree/master/csi</td></tr>
 <tr><td><a href="https://portworx.com/">Portworx</a> </td><td> Alpha </td><td> CSI implementation is available <a href="https://github.com/libopenstorage/openstorage/tree/master/csi">here</a> which can be used as an example also.</td></tr>

--- a/docs/Drivers.html
+++ b/docs/Drivers.html
@@ -127,21 +127,21 @@
 </blockquote>
 <a class="header" href="Drivers.html#sample-drivers" id="sample-drivers"><h3>Sample Drivers</h3></a>
 <table><thead><tr><th>Name </th><th> Status </th><th> More Information</th></tr></thead><tbody>
-<tr><td><a href="https://github.com/kubernetes-csi/drivers/tree/master/pkg/nfs">NFS</a> </td><td> Sample </td></tr>
-<tr><td><a href="https://github.com/kubernetes-csi/drivers/tree/master/pkg/hostpath">HostPath</a> </td><td> v0.2.0 </td><td> Only use for a single node tests. See the <a href="Example.html">Example</a> page for Kubernetes-specific instructions.</td></tr>
 <tr><td><a href="https://github.com/kubernetes-csi/drivers/tree/master/pkg/flexadapter">Flexvolume</a> </td><td> Sample </td></tr>
+<tr><td><a href="https://github.com/kubernetes-csi/drivers/tree/master/pkg/hostpath">HostPath</a> </td><td> v0.2.0 </td><td> Only use for a single node tests. See the <a href="Example.html">Example</a> page for Kubernetes-specific instructions.</td></tr>
 <tr><td><a href="https://github.com/kubernetes-csi/drivers/mock">Mock Driver</a> </td><td> v0.2.0 </td><td> A mock CSI plugin usable as a stand-alone binary or in code.</td></tr>
+<tr><td><a href="https://github.com/kubernetes-csi/drivers/tree/master/pkg/nfs">NFS</a> </td><td> Sample </td></tr>
 <tr><td><a href="https://github.com/thecodeteam/csi-vfs">VFS Driver</a> </td><td> Released </td><td> A CSI plugin that provides a virtual file system.</td></tr>
 </tbody></table>
 <a class="header" href="Drivers.html#production-drivers" id="production-drivers"><h3>Production Drivers</h3></a>
 <table><thead><tr><th>Name </th><th> Status </th><th> More Information</th></tr></thead><tbody>
-<tr><td><a href="https://portworx.com/">Portworx</a> </td><td> Alpha </td><td> CSI implementation is available <a href="https://github.com/libopenstorage/openstorage/tree/master/csi">here</a> which can be used as an example also.</td></tr>
-<tr><td><a href="https://www.opensds.io/">OpenSDS</a> </td><td> Beta </td><td> For more information, please visit <a href="https://github.com/opensds/nbp/releases">releases</a> and https://github.com/opensds/nbp/tree/master/csi</td></tr>
-<tr><td><a href="https://github.com/thecodeteam/csi-scaleio">ScaleIO</a></td><td>v0.1.0</td><td>A Container Storage Interface (CSI) Storage Plugin for DellEMC ScaleIO</td></tr>
-<tr><td><a href="https://github.com/thecodeteam/csi-vsphere">vSphere</a></td><td>v0.1.0</td><td>A Container Storage Interface (CSI) Storage Plug-in for VMware vSphere</td></tr>
-<tr><td><a href="https://github.com/ceph/ceph-csi">RBD</a></td><td>v0.2.0</td><td>A Container Storage Interface (CSI) Storage RBD Plug-in for Ceph</td></tr>
 <tr><td><a href="https://github.com/kubernetes/cloud-provider-openstack/tree/master/pkg/csi/cinder">Cinder</a></td><td>v0.2.0</td><td>A Container Storage Interface (CSI) Storage Plug-in for Cinder</td></tr>
 <tr><td><a href="https://github.com/GoogleCloudPlatform/compute-persistent-disk-csi-driver">GCE Persistent Disk</a></td><td>Alpha</td><td>A Container Storage Interface (CSI) Storage Plugin for Google Compute Engine Persistent Disk</td></tr>
+<tr><td><a href="https://www.opensds.io/">OpenSDS</a> </td><td> Beta </td><td> For more information, please visit <a href="https://github.com/opensds/nbp/releases">releases</a> and https://github.com/opensds/nbp/tree/master/csi</td></tr>
+<tr><td><a href="https://portworx.com/">Portworx</a> </td><td> Alpha </td><td> CSI implementation is available <a href="https://github.com/libopenstorage/openstorage/tree/master/csi">here</a> which can be used as an example also.</td></tr>
+<tr><td><a href="https://github.com/ceph/ceph-csi">RBD</a></td><td>v0.2.0</td><td>A Container Storage Interface (CSI) Storage RBD Plug-in for Ceph</td></tr>
+<tr><td><a href="https://github.com/thecodeteam/csi-scaleio">ScaleIO</a></td><td>v0.1.0</td><td>A Container Storage Interface (CSI) Storage Plugin for DellEMC ScaleIO</td></tr>
+<tr><td><a href="https://github.com/thecodeteam/csi-vsphere">vSphere</a></td><td>v0.1.0</td><td>A Container Storage Interface (CSI) Storage Plug-in for VMware vSphere</td></tr>
 </tbody></table>
 <a class="header" href="Drivers.html#testing" id="testing"><h2>Testing</h2></a>
 <p>There are multiple ways to test your driver. Please see <a href="Testing-Drivers.html">Testing Drivers</a> for more information.</p>

--- a/docs/print.html
+++ b/docs/print.html
@@ -149,21 +149,21 @@
 </blockquote>
 <a class="header" href="print.html#sample-drivers" id="sample-drivers"><h3>Sample Drivers</h3></a>
 <table><thead><tr><th>Name </th><th> Status </th><th> More Information</th></tr></thead><tbody>
-<tr><td><a href="https://github.com/kubernetes-csi/drivers/tree/master/pkg/nfs">NFS</a> </td><td> Sample </td></tr>
-<tr><td><a href="https://github.com/kubernetes-csi/drivers/tree/master/pkg/hostpath">HostPath</a> </td><td> v0.2.0 </td><td> Only use for a single node tests. See the <a href="Example.html">Example</a> page for Kubernetes-specific instructions.</td></tr>
 <tr><td><a href="https://github.com/kubernetes-csi/drivers/tree/master/pkg/flexadapter">Flexvolume</a> </td><td> Sample </td></tr>
+<tr><td><a href="https://github.com/kubernetes-csi/drivers/tree/master/pkg/hostpath">HostPath</a> </td><td> v0.2.0 </td><td> Only use for a single node tests. See the <a href="Example.html">Example</a> page for Kubernetes-specific instructions.</td></tr>
 <tr><td><a href="https://github.com/kubernetes-csi/drivers/mock">Mock Driver</a> </td><td> v0.2.0 </td><td> A mock CSI plugin usable as a stand-alone binary or in code.</td></tr>
+<tr><td><a href="https://github.com/kubernetes-csi/drivers/tree/master/pkg/nfs">NFS</a> </td><td> Sample </td></tr>
 <tr><td><a href="https://github.com/thecodeteam/csi-vfs">VFS Driver</a> </td><td> Released </td><td> A CSI plugin that provides a virtual file system.</td></tr>
 </tbody></table>
 <a class="header" href="print.html#production-drivers" id="production-drivers"><h3>Production Drivers</h3></a>
 <table><thead><tr><th>Name </th><th> Status </th><th> More Information</th></tr></thead><tbody>
-<tr><td><a href="https://portworx.com/">Portworx</a> </td><td> Alpha </td><td> CSI implementation is available <a href="https://github.com/libopenstorage/openstorage/tree/master/csi">here</a> which can be used as an example also.</td></tr>
-<tr><td><a href="https://www.opensds.io/">OpenSDS</a> </td><td> Beta </td><td> For more information, please visit <a href="https://github.com/opensds/nbp/releases">releases</a> and https://github.com/opensds/nbp/tree/master/csi</td></tr>
-<tr><td><a href="https://github.com/thecodeteam/csi-scaleio">ScaleIO</a></td><td>v0.1.0</td><td>A Container Storage Interface (CSI) Storage Plugin for DellEMC ScaleIO</td></tr>
-<tr><td><a href="https://github.com/thecodeteam/csi-vsphere">vSphere</a></td><td>v0.1.0</td><td>A Container Storage Interface (CSI) Storage Plug-in for VMware vSphere</td></tr>
-<tr><td><a href="https://github.com/ceph/ceph-csi">RBD</a></td><td>v0.2.0</td><td>A Container Storage Interface (CSI) Storage RBD Plug-in for Ceph</td></tr>
 <tr><td><a href="https://github.com/kubernetes/cloud-provider-openstack/tree/master/pkg/csi/cinder">Cinder</a></td><td>v0.2.0</td><td>A Container Storage Interface (CSI) Storage Plug-in for Cinder</td></tr>
 <tr><td><a href="https://github.com/GoogleCloudPlatform/compute-persistent-disk-csi-driver">GCE Persistent Disk</a></td><td>Alpha</td><td>A Container Storage Interface (CSI) Storage Plugin for Google Compute Engine Persistent Disk</td></tr>
+<tr><td><a href="https://www.opensds.io/">OpenSDS</a> </td><td> Beta </td><td> For more information, please visit <a href="https://github.com/opensds/nbp/releases">releases</a> and https://github.com/opensds/nbp/tree/master/csi</td></tr>
+<tr><td><a href="https://portworx.com/">Portworx</a> </td><td> Alpha </td><td> CSI implementation is available <a href="https://github.com/libopenstorage/openstorage/tree/master/csi">here</a> which can be used as an example also.</td></tr>
+<tr><td><a href="https://github.com/ceph/ceph-csi">RBD</a></td><td>v0.2.0</td><td>A Container Storage Interface (CSI) Storage RBD Plug-in for Ceph</td></tr>
+<tr><td><a href="https://github.com/thecodeteam/csi-scaleio">ScaleIO</a></td><td>v0.1.0</td><td>A Container Storage Interface (CSI) Storage Plugin for DellEMC ScaleIO</td></tr>
+<tr><td><a href="https://github.com/thecodeteam/csi-vsphere">vSphere</a></td><td>v0.1.0</td><td>A Container Storage Interface (CSI) Storage Plug-in for VMware vSphere</td></tr>
 </tbody></table>
 <a class="header" href="print.html#testing" id="testing"><h2>Testing</h2></a>
 <p>There are multiple ways to test your driver. Please see <a href="Testing-Drivers.html">Testing Drivers</a> for more information.</p>

--- a/docs/print.html
+++ b/docs/print.html
@@ -158,6 +158,7 @@
 <a class="header" href="print.html#production-drivers" id="production-drivers"><h3>Production Drivers</h3></a>
 <table><thead><tr><th>Name </th><th> Status </th><th> More Information</th></tr></thead><tbody>
 <tr><td><a href="https://github.com/kubernetes/cloud-provider-openstack/tree/master/pkg/csi/cinder">Cinder</a></td><td>v0.2.0</td><td>A Container Storage Interface (CSI) Storage Plug-in for Cinder</td></tr>
+<tr><td><a href="https://github.com/digitalocean/csi-digitalocean">DigitalOcean Block Storage</a> </td><td> v0.0.1 (alpha) </td><td> A Container Storage Interface (CSI) Driver for DigitalOcean Block Storage</td></tr>
 <tr><td><a href="https://github.com/GoogleCloudPlatform/compute-persistent-disk-csi-driver">GCE Persistent Disk</a></td><td>Alpha</td><td>A Container Storage Interface (CSI) Storage Plugin for Google Compute Engine Persistent Disk</td></tr>
 <tr><td><a href="https://www.opensds.io/">OpenSDS</a> </td><td> Beta </td><td> For more information, please visit <a href="https://github.com/opensds/nbp/releases">releases</a> and https://github.com/opensds/nbp/tree/master/csi</td></tr>
 <tr><td><a href="https://portworx.com/">Portworx</a> </td><td> Alpha </td><td> CSI implementation is available <a href="https://github.com/libopenstorage/openstorage/tree/master/csi">here</a> which can be used as an example also.</td></tr>


### PR DESCRIPTION
This adds DigitalOcean Block Storage, as requested in
kubernetes-csi/docs#21. While at it, the list gets sorted
alphabetically because the current order seemed arbitrary.