### PR TITLE
fix misspelling

### DIFF
--- a/docs/Setup.html
+++ b/docs/Setup.html
@@ -153,7 +153,7 @@ watcher for CSI plugins:</p>
 <pre><code>--feature-gates=KubeletPluginsWatcher=true
 </code></pre>
 <p>You will also need to use the following flag in your <code>driver-registrar</code> side-car
-container with the value set to the location of kubekel plugin watcher socket:</p>
+container with the value set to the location of kubelet plugin watcher socket:</p>
 <pre><code>--kubelet-registration-path: Enables Kubelet Plugin Registration service, and returns
   the specified path as &quot;endpoint&quot; in &quot;PluginInfo&quot; response. If this option is set, the
   driver-registrar expose a unix domain socket to handle Kubelet Plugin Registration,


### PR DESCRIPTION
The author may want to write `kubelet plugin watcher socket` instead of `kubekel plugin watcher socket` .