### PR TITLE
add makefile to generate book using docker image of mdbook 0.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # The example references the latest .yaml file directly in the source repository,
 # therefore we don't need the copy in the generated documentation.
 docs/example
+
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+doc:
+	docker run --rm -v $(CURDIR):/data -u $(id -u):$(id -g) -it chengpan/mdbook:0.2.1 mdbook build ./book


### PR DESCRIPTION
add makefile to generate book using docker image for mdbook 0.2.1. With this, people just need to run `make doc` to generate docs without installing extra rust dependencies