### PR TITLE
Fix typo in example and deploying

### DIFF
--- a/book/src/CSI-Kubernetes.md
+++ b/book/src/CSI-Kubernetes.md
@@ -7,7 +7,7 @@ There are three components plus the kubelet that enable CSI drivers to provide s
 ## Sidecar Containers
 [![sidecar-container](images/sidecar-container.png)](https://docs.google.com/a/greatdanedata.com/drawings/d/1JExJ_98dt0NAsJ7iI0_9loeTn2rbLeEcpOMEvKrF-9w/edit?usp=sharing)
 
-Sidecar containers manage Kubernetes events and make the appropriate calls to the CSI driver. These are the _external attacher_, _external provisioner_, and the _driver registrar_.
+Sidecar containers manage Kubernetes events and make the appropriate calls to the CSI driver. These are the _external attacher_, _external provisioner_, _external snapshotter_ and the _driver registrar_.
 
 ### External Attacher
 [external-attacher](https://github.com/kubernetes-csi/external-attacher) is a sidecar container that watches Kubernetes _VolumeAttachment_ objects and triggers CSI _ControllerPublish_ and _ControllerUnpublish_ operations against a driver endpoint. As of this writing, the external attacher does not support leader election and therefore there can be only one running per CSI driver.  For more information please read [_Attaching and Detaching_](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface.md#attaching-and-detaching).

--- a/book/src/Setup.md
+++ b/book/src/Setup.md
@@ -29,7 +29,7 @@ Another feature that CSI depends on is mount propagation.  It allows the sharing
 ## Enable raw block volume support (alpha)
 
 Kubernetes now has [raw block volume Support][rawsupport] as an alpha implementation. If you want to use the 
-[CSI raw block volume support][rawvol], you must enable the feature (for your Kubernetes binaries including server, kubelet, controller manager, etc) with the  `feature-gates` flag as follow:
+[CSI raw block volume support][rawvol], you must enable the feature (for your Kubernetes binaries including apiserver, kubelet, controller manager, etc) with the  `feature-gates` flag as follow:
 
 ```
 $ kube<binary> --feature-gates=BlockVolume=true,CSIBlockVolume=true ...
@@ -144,7 +144,7 @@ $> kubectl create -f https://raw.githubusercontent.com/kubernetes/csi-api/master
 
 ## CSI driver discovery (beta)
 
-The CSI driver discovery uses the [Kubelet Plugin Watcher][plugin-watcher] feature which allows Kubelet to discover deployed CSI drivers automatically.  The registrar sidecar container exposes an internal registration server via a Unix data socket path. The Kubelet monitors its `registration` directory to detect new registration requests. Once detected, the Kubelet contacts the registrar sidecar to query driver information.  The retrieved CSI driver information (including the driver's own socket path) will be used for further interaction with the driver.
+The CSI driver discovery uses the [Kubelet Plugin Watcher][plugin-watcher] feature which allows Kubelet to discover deployed CSI drivers automatically.  The registrar sidecar container exposes an internal registration server via a Unix domain socket path. The Kubelet monitors its `registration` directory to detect new registration requests. Once detected, the Kubelet contacts the registrar sidecar to query driver information.  The retrieved CSI driver information (including the driver's own socket path) will be used for further interaction with the driver.
 
 > This replaces the previous driver registration mechanism, where the driver-registrar sidecar, rather than kubelet, handles registration.
 
@@ -171,7 +171,7 @@ To configure your driver using the registrar sidecar, you can configure the cont
         fieldRef:
           apiVersion: v1
           fieldPath: spec.nodeName
-    image: quay.io/k8scsi/driver-registrar:v0.2.0
+    image: quay.io/k8scsi/driver-registrar:v0.4.1
     imagePullPolicy: Always
     volumeMounts:
     - mountPath: /csi


### PR DESCRIPTION
1. add `external snapshotter` in Sidecar Containers section
2. modify `server` to `apiserver` in Enable raw block volume support (alpha) section
3. modify `Unix data socket` to `Unix domain socket` in CSI driver discovery (beta) section
4. update the driver-registrar image's tag to `v0.4.1`