### PR TITLE
Example: update external-snapshotter RBAC link

### DIFF
--- a/book/src/Example.md
+++ b/book/src/Example.md
@@ -78,7 +78,7 @@ Only the `driver-registrar` interacts directly with Kubernetes, so it's those RB
 The CSI snapshotter is an optional sidecar container. You only need to create these
 RBAC rules if you want to test the snapshot feature.
 
-> $ kubectl create -f [https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/51482343dc7f81fef64e3ec32ea3f48fec17b9cf/deploy/kubernetes/rbac.yaml](https://github.com/kubernetes-csi/external-snapshotter/blob/51482343dc7f81fef64e3ec32ea3f48fec17b9cf/deploy/kubernetes/rbac.yaml)
+> $ kubectl create -f [https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/01bd7f356e6718dee87914232d287631655bef1d/deploy/kubernetes/rbac.yaml](https://github.com/kubernetes-csi/external-snapshotter/blob/01bd7f356e6718dee87914232d287631655bef1d/deploy/kubernetes/rbac.yaml)
 > ```
 > serviceaccount/csi-snapshotter created
 > clusterrole.rbac.authorization.k8s.io/external-snapshotter-runner created


### PR DESCRIPTION
This includes the following change:

commit 137ac8a6fbe969a02de4ed3256f90855dbda7c89
Author: xushiwei <xushiwei5@huawei.com>
Date:   Tue Nov 13 16:11:04 2018 +0800

    fix RABC rule

diff --git a/deploy/kubernetes/rbac.yaml b/deploy/kubernetes/rbac.yaml
index 264658a215..7bfdb81be5 100644
--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -22,10 +22,10 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]