### PR TITLE
Add v1.1.1 release to external-provisioner docs

### DIFF
--- a/book/src/external-provisioner.md
+++ b/book/src/external-provisioner.md
@@ -8,7 +8,7 @@
 
 Latest stable release | Branch | Min CSI Version | Max CSI Version | Container Image | Min K8s Version | Max K8s Version | Recommended K8s Version
 --|--|--|--|--|--|--|--
-[external-provisioner v1.1.0](https://github.com/kubernetes-csi/external-provisioner/releases/tag/v1.1.0) | [release-1.1](https://github.com/kubernetes-csi/external-provisioner/tree/release-1.1) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | quay.io/k8scsi/csi-provisioner:v1.1.0 | v1.13 | - | v1.14
+[external-provisioner v1.1.1](https://github.com/kubernetes-csi/external-provisioner/releases/tag/v1.1.1) | [release-1.1](https://github.com/kubernetes-csi/external-provisioner/tree/release-1.1) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | quay.io/k8scsi/csi-provisioner:v1.1.1 | v1.13 | - | v1.14
 [external-provisioner v1.0.1](https://github.com/kubernetes-csi/external-provisioner/releases/tag/v1.0.1) | [release-1.0](https://github.com/kubernetes-csi/external-provisioner/tree/release-1.0) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | quay.io/k8scsi/csi-provisioner:v1.0.1 | v1.13 | - | v1.13
 [external-provisioner v0.4.2](https://github.com/kubernetes-csi/external-provisioner/releases/tag/v0.4.2) | [release-0.4](https://github.com/kubernetes-csi/external-provisioner/tree/release-0.4) | [v0.3.0](https://github.com/container-storage-interface/spec/releases/tag/v0.3.0) | [v0.3.0](https://github.com/container-storage-interface/spec/releases/tag/v0.3.0) | quay.io/k8scsi/csi-provisioner:v0.4.2 | v1.10 | -| v1.10
 


### PR DESCRIPTION
Quick change - noticed that the v1.1.1 external-provisioner doc link was missing

```release-note
NONE
```