### PR TITLE
remind people to add secret RBAC rules

### DIFF
--- a/book/src/secrets-and-credentials.md
+++ b/book/src/secrets-and-credentials.md
@@ -35,6 +35,14 @@ parameters:
   csi.storage.k8s.io/provisioner-secret-namespace: pd-ssd-credentials
 ```
 
+### Secret RBAC Rules
+
+For reducing RBAC permissions as much as possible, secret rules are disabled in each sidecar repository by default.
+
+Please add or update RBAC rules if secret is expected to use.
+
+To set proper secret permission, uncomment related lines defined in `rbac.yaml` (e.g. [external-provisioner/deploy/kubernetes/rbac.yaml](https://github.com/kubernetes-csi/external-provisioner/blob/22bb6401d2484ee3ca18a23d75c3864c774e5f32/deploy/kubernetes/rbac.yaml#L24))
+
 ### Create/Delete Volume Secret
 
 The CSI `external-provisioner` (v1.0.1+) looks for the following keys in `StorageClass.parameters`:


### PR DESCRIPTION
secret rbac rules is optional in [`external-attacher`](https://github.com/kubernetes-csi/external-attacher/blob/master/deploy/kubernetes/rbac.yaml) and [`external-provisioner`](https://github.com/kubernetes-csi/external-provisioner/blob/master/deploy/kubernetes/rbac.yaml)
remind user to enable it when secret is required.
see [#152](https://github.com/kubernetes-csi/external-attacher/pull/152#discussion_r291007506)