### PR TITLE
Deprecate cluster-driver-registrar

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -8,7 +8,7 @@
         - [external-attacher](external-attacher.md)
         - [external-snapshotter](external-snapshotter.md)
         - [node-driver-registrar](node-driver-registrar.md)
-        - [cluster-driver-registrar](cluster-driver-registrar.md)
+        - [cluster-driver-registrar](cluster-driver-registrar.md) (deprecated)
         - [livenessprobe](livenessprobe.md)
         - [external-resizer](external-resizer.md)
     - [CSI objects](csi-objects.md)

--- a/book/src/cluster-driver-registrar.md
+++ b/book/src/cluster-driver-registrar.md
@@ -1,12 +1,15 @@
 # CSI cluster-driver-registrar
 
-## UNDER CONSTRUCTION
+## Deprecated
 
-As of Kubernetes 1.14, this side car container is being refactored. The purpose of
-this side car container was to automatically register a _CSIDriver_ object containing
-information about the driver with Kubernetes. We are currently refactoring this
-side car container to be more efficient. In the meantime, developers will now
-have to add a CSIDriver object in their installation manifest.
+This sidecar container was not updated since Kubernetes 1.13. As of Kubernetes
+1.16, this side car container is officially deprecated.
+
+The purpose of this side car container was to automatically register
+a _CSIDriver_ object containing information about the driver with Kubernetes.
+Without this side car, developers and CSI driver vendors will now have to add
+a CSIDriver object in their installation manifest or any tool that installs
+their CSI driver.
 
 Please see [CSIDriver](csi-driver-object.md) for more information.
 

--- a/book/src/csi-driver-object.md
+++ b/book/src/csi-driver-object.md
@@ -52,8 +52,12 @@ To install, a CSI driver's deployment manifest must contain a `CSIDriver`
 object as shown in the example above.
 
 >NOTE: The cluster-driver-registrar side-car which was used to create CSIDriver
->objects in Kubernetes 1.13 is being redesigned for Kubernetes 1.15 and
->therefore not available for Kubernetes 1.14.
+>objects in Kubernetes 1.13 has been deprecated for Kubernetes 1.16. No
+>cluster-driver-registrar has been released for Kubernetes 1.14 and later.
+
+`CSIDriver` instance should exist for whole lifetime of all pods that use
+volumes provided by corresponding CSI driver, so [Skip Attach](skip-attach.md)
+and [Pod Info on Mount](pod-info.md) features work correctly.
 
 ### Listing registered CSI drivers
 Using the `CSIDriver` object, it is now possible to query Kubernetes to get a list of registered drivers running in the cluster as shown below:

--- a/book/src/sidecar-containers.md
+++ b/book/src/sidecar-containers.md
@@ -24,7 +24,7 @@ The Kubernetes development team maintains the following Kubernetes CSI Sidecar C
 * [external-snapshotter](external-snapshotter.md)
 * [external-resizer](external-resizer.md)
 * [node-driver-registrar](node-driver-registrar.md)
-* [cluster-driver-registrar](cluster-driver-registrar.md)
+* [cluster-driver-registrar](cluster-driver-registrar.md) (deprecated)
 * [livenessprobe](livenessprobe.md)
 
 


### PR DESCRIPTION
Related to https://github.com/kubernetes-csi/cluster-driver-registrar/issues/48

```release-note
cluster-driver-registrar has been deprecated
```