### PR TITLE
Add note about what versions are supported

### DIFF
--- a/book/src/external-attacher.md
+++ b/book/src/external-attacher.md
@@ -13,7 +13,7 @@ Latest stable release | Branch | Min CSI Version | Max CSI Version | Container I
 [external-attacher v1.0.1](https://github.com/kubernetes-csi/external-attacher/releases/tag/v1.0.1) | [release-1.0](https://github.com/kubernetes-csi/external-attacher/tree/release-1.0) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | quay.io/k8scsi/csi-attacher:v1.0.1 | v1.13 | - | v1.13
 [external-attacher v0.4.2](https://github.com/kubernetes-csi/external-attacher/releases/tag/v0.4.2) | [release-0.4](https://github.com/kubernetes-csi/external-attacher/tree/release-0.4) | [v0.3.0](https://github.com/container-storage-interface/spec/releases/tag/v0.3.0) | [v0.3.0](https://github.com/container-storage-interface/spec/releases/tag/v0.3.0) | quay.io/k8scsi/csi-attacher:v0.4.2 | v1.10 | - | v1.10
 
-Definitions of the min/max/recommended Kubernetes versions can be found on the
+Definitions of the min/max/recommended Kubernetes versions and supported sidecar versions can be found on the
 [sidecar page](sidecar-containers.md#versioning)
 
 ## Description

--- a/book/src/external-provisioner.md
+++ b/book/src/external-provisioner.md
@@ -13,7 +13,7 @@ Latest stable release | Branch | Min CSI Version | Max CSI Version | Container I
 [external-provisioner v1.0.1](https://github.com/kubernetes-csi/external-provisioner/releases/tag/v1.0.1) | [release-1.0](https://github.com/kubernetes-csi/external-provisioner/tree/release-1.0) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | quay.io/k8scsi/csi-provisioner:v1.0.1 | v1.13 | - | v1.13
 [external-provisioner v0.4.2](https://github.com/kubernetes-csi/external-provisioner/releases/tag/v0.4.2) | [release-0.4](https://github.com/kubernetes-csi/external-provisioner/tree/release-0.4) | [v0.3.0](https://github.com/container-storage-interface/spec/releases/tag/v0.3.0) | [v0.3.0](https://github.com/container-storage-interface/spec/releases/tag/v0.3.0) | quay.io/k8scsi/csi-provisioner:v0.4.2 | v1.10 | -| v1.10
 
-Definitions of the min/max/recommended Kubernetes versions can be found on the
+Definitions of the min/max/recommended Kubernetes versions and supported sidecar versions can be found on the
 [sidecar page](sidecar-containers.md#versioning)
 
 ## Description

--- a/book/src/external-resizer.md
+++ b/book/src/external-resizer.md
@@ -11,7 +11,7 @@ Latest release | Branch | Min CSI Version | Max CSI Version | Container Image | 
 [external-resizer v0.2.0](https://github.com/kubernetes-csi/external-resizer/tree/v0.2.0)  | [master](https://github.com/kubernetes-csi/external-resizer/tree/master) |[v1.1.0](https://github.com/container-storage-interface/spec/releases/tag/v1.1.0) | - | quay.io/k8scsi/csi-resizer:v0.2.0 | v1.15 | - | v1.15
 [external-resizer v0.1.0](https://github.com/kubernetes-csi/external-resizer/tree/v0.1.0)  | [master](https://github.com/kubernetes-csi/external-resizer/tree/master) |[v1.1.0](https://github.com/container-storage-interface/spec/releases/tag/v1.1.0) | - | quay.io/k8scsi/csi-resizer:v0.1.0 | v1.14 | v1.14 | v1.14
 
-Definitions of the min/max/recommended Kubernetes versions can be found on the
+Definitions of the min/max/recommended Kubernetes versions and supported sidecar versions can be found on the
 [sidecar page](sidecar-containers.md#versioning)
 
 ## Description

--- a/book/src/external-snapshotter.md
+++ b/book/src/external-snapshotter.md
@@ -12,7 +12,7 @@ Latest stable release | Branch | Min CSI Version | Max CSI Version | Container I
 [external-snapshotter v1.0.1](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v1.0.1) | [release-1.0](https://github.com/kubernetes-csi/external-snapshotter/tree/release-1.0) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | quay.io/k8scsi/csi-snapshotter:v1.0.1 | v1.13 | - | v1.13
 [external-snapshotter v0.4.1](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v0.4.1) | [release-0.4](https://github.com/kubernetes-csi/external-snapshotter/tree/release-0.4) | [v0.3.0](https://github.com/container-storage-interface/spec/releases/tag/v0.3.0) | [v0.3.0](https://github.com/container-storage-interface/spec/releases/tag/v0.3.0) | quay.io/k8scsi/csi-snapshotter:v0.4.1 | v1.10 | -| v.10
 
-Definitions of the min/max/recommended Kubernetes versions can be found on the
+Definitions of the min/max/recommended Kubernetes versions and supported sidecar versions can be found on the
 [sidecar page](sidecar-containers.md#versioning)
 
 ## Description

--- a/book/src/livenessprobe.md
+++ b/book/src/livenessprobe.md
@@ -12,6 +12,9 @@ Latest stable release | Branch | Compatible with CSI Version | Container Image |
 [livenessprobe v1.0.2](https://github.com/kubernetes-csi/livenessprobe/releases/tag/v1.0.2) | [release-1.0](https://github.com/kubernetes-csi/livenessprobe/tree/release-1.0) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | quay.io/k8scsi/livenessprobe:v1.0.2 | v1.13 | -
 Unsupported. | No 0.x branch. | [v0.3.0](https://github.com/container-storage-interface/spec/releases/tag/v0.3.0) | quay.io/k8scsi/livenessprobe:v0.4.1 | v1.10 | -
 
+Definitions of the min/max/recommended Kubernetes versions and supported sidecar versions can be found on the
+[sidecar page](sidecar-containers.md#versioning)
+
 ## Description
 
 The CSI `livenessprobe` is a sidecar container that monitors the health of the CSI driver and reports it to Kubernetes via the [Liveness Probe mechanism](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/). This enables Kubernetes to automatically detect issues with the driver and restart the pod to try and fix the issue.

--- a/book/src/node-driver-registrar.md
+++ b/book/src/node-driver-registrar.md
@@ -12,6 +12,9 @@ Latest stable release | Branch | Min CSI Version | Max CSI Version | Container I
 [node-driver-registrar v1.0.2](https://github.com/kubernetes-csi/node-driver-registrar/releases/tag/v1.0.2) | [release-1.0](https://github.com/kubernetes-csi/node-driver-registrar/tree/release-1.0) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | quay.io/k8scsi/csi-node-driver-registrar:v1.0.2 | v1.13 | -
 [driver-registrar v0.4.2](https://github.com/kubernetes-csi/driver-registrar/releases/tag/v0.4.2) | [release-0.4](https://github.com/kubernetes-csi/driver-registrar/tree/release-0.4) | [v0.3.0](https://github.com/container-storage-interface/spec/releases/tag/v0.3.0) | [v0.3.0](https://github.com/container-storage-interface/spec/releases/tag/v0.3.0) | quay.io/k8scsi/driver-registrar:v0.4.2 | v1.10 | -
 
+Definitions of the min/max/recommended Kubernetes versions and supported sidecar versions can be found on the
+[sidecar page](sidecar-containers.md#versioning)
+
 ## Description
 
 The CSI `node-driver-registrar` is a sidecar container that fetches driver information (using `NodeGetInfo`) from a CSI endpoint and registers it with the kubelet on that node using the [kubelet plugin registration mechanism](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#device-plugin-registration).

--- a/book/src/sidecar-containers.md
+++ b/book/src/sidecar-containers.md
@@ -57,6 +57,13 @@ stay as close to the recommended Kubernetes version as possible.
 For more details on which features are supported with which Kubernetes versions
 and their corresponding sidecars, please see each feature's individual page.
 
+### Support
+
+Kubernetes community supports CSI sidecar container versions that cover at
+least one
+[supported Kubernetes version](https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-versions)
+between their minimum and maximum versions.
+
 ### Alpha Features
 
 It is also important to note that alpha features are subject to break or be


### PR DESCRIPTION
We talked about this on our meeting yesterday. We should support all containers that include a supported Kubernetes version between their min/max versions.

From tables of individual containers, it seems we're going to support quite lot of branches (e.g. at least 3 external-provisioners), because we don't really set max k8s version unless it really breaks something and at the same time we open new 1.x branch every Kubernetes release.

cc @msau42 @pohly @kubernetes-csi/csi-misc
