### PR TITLE
Update cloning to Beta

### DIFF
--- a/book/src/kubernetes-changelog.md
+++ b/book/src/kubernetes-changelog.md
@@ -3,6 +3,14 @@
 This page summarizes major CSI changes made in each Kubernetes release. For
 details on individual features, visit the [Features section](features.md).
 
+## Kubernetes 1.16
+
+### Features
+* New beta features:
+    * Volume cloning
+    * Volume expansion
+    * Ephemeral local volumes
+
 ## Kubernetes 1.15
 
 ### Features

--- a/book/src/volume-cloning.md
+++ b/book/src/volume-cloning.md
@@ -4,7 +4,8 @@
 
 Status | Min k8s Version | Max k8s version | external-provisioner Version
 --|--|--|--
-Alpha | 1.15 | - | 1.3
+Alpha | 1.15 | 1.15 | 1.3
+Beta | 1.16 | - | 1.3
 
 ## Overview
 
@@ -29,7 +30,7 @@ There are no additional side-cars or add on components required.
 
 ## Enabling Cloning for CSI volumes in Kubernetes
 
-Volume cloning for CSI volumes is an alpha feature (Kubernetes 1.15) and hence must be explicitly enabled via feature gate:
+In Kubernetes 1.15 this feature was alpha status and required enabling the appropriate feature gate:
 
 ```
 --feature-gates=VolumePVCDataSource=true


### PR DESCRIPTION
Update docs to reflect promotion of volume cloning.

Add "New beta features" for 1.16 to the change log and include expansion and ephemeral local-volumes while we're adding cloning.

```release-note
NONE
```