### PR TITLE
Update change log for CSI spec 1.1.0 and 1.2.0

### DIFF
--- a/book/src/kubernetes-changelog.md
+++ b/book/src/kubernetes-changelog.md
@@ -14,6 +14,7 @@ details on individual features, visit the [Features section](features.md).
 
 ### Features
 * GA
+    * Support for [CSI spec 1.2.0](https://github.com/container-storage-interface/spec/releases/tag/v1.2.0).
     * Volume topology
     * Volume limits
 * Beta
@@ -32,7 +33,9 @@ details on individual features, visit the [Features section](features.md).
 ## Kubernetes 1.15
 
 ### Features
-* Volume capacity usage metrics
+* GA
+  * Support for [CSI spec 1.1.0](https://github.com/container-storage-interface/spec/releases/tag/v1.1.0).
+  * Volume capacity usage metrics
 * Alpha
     * Volume cloning
     * Ephemeral local volumes


### PR DESCRIPTION
I assumed that both CSI releases went GA with their respective Kubernetes versions.

Also assumed Volume capacity usage metrics went GA with 1.15 in order to group it under the GA header.

Please let me know if either is incorrect.

```release-note
NONE
```