### PR TITLE
modify the error url of livenessprobe

### DIFF
--- a/book/src/livenessprobe.md
+++ b/book/src/livenessprobe.md
@@ -8,7 +8,7 @@
 
 Latest stable release | Branch | Compatible with CSI Version | Container Image | Min k8s Version | Max k8s version
 --|--|--|--|--|--
-[livenessprobe v1.1.0](https://github.com/kubernetes-csi/livenessprobe/releases/tag/v1.1.0) | [release-1.1](https://github.com/kubernetes-csi/livenessprobe/tree/release-1.0) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | quay.io/k8scsi/livenessprobe:v1.1.0 | v1.13 | -
+[livenessprobe v1.1.0](https://github.com/kubernetes-csi/livenessprobe/releases/tag/v1.1.0) | [release-1.1](https://github.com/kubernetes-csi/livenessprobe/tree/release-1.x) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | quay.io/k8scsi/livenessprobe:v1.1.0 | v1.13 | -
 Unsupported. | No 0.x branch. | [v0.3.0](https://github.com/container-storage-interface/spec/releases/tag/v0.3.0) | quay.io/k8scsi/livenessprobe:v0.4.1 | v1.10 | v1.16
 
 ## Description

--- a/book/src/livenessprobe.md
+++ b/book/src/livenessprobe.md
@@ -8,7 +8,7 @@
 
 Latest stable release | Branch | Compatible with CSI Version | Container Image | Min k8s Version | Max k8s version
 --|--|--|--|--|--
-[livenessprobe v1.1.0](https://github.com/kubernetes-csi/livenessprobe/releases/tag/v1.1.0) | [release-1.1](https://github.com/kubernetes-csi/livenessprobe/tree/release-1.1) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | quay.io/k8scsi/livenessprobe:v1.1.0 | v1.13 | -
+[livenessprobe v1.1.0](https://github.com/kubernetes-csi/livenessprobe/releases/tag/v1.1.0) | [release-1.1](https://github.com/kubernetes-csi/livenessprobe/tree/release-1.0) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | quay.io/k8scsi/livenessprobe:v1.1.0 | v1.13 | -
 Unsupported. | No 0.x branch. | [v0.3.0](https://github.com/container-storage-interface/spec/releases/tag/v0.3.0) | quay.io/k8scsi/livenessprobe:v0.4.1 | v1.10 | v1.16
 
 ## Description


### PR DESCRIPTION
/kind bug
/sig docs

the error url is:
https://github.com/kubernetes-csi/livenessprobe/tree/release-1.1

the right url is:
https://github.com/kubernetes-csi/livenessprobe/tree/release-1.0