### PR TITLE
modify the error url of e2e-tests

### DIFF
--- a/book/src/_book/Troubleshooting.html
+++ b/book/src/_book/Troubleshooting.html
@@ -401,7 +401,7 @@ E0306 16:34:50.992034       1 reflector.go:205] github.com/kubernetes-csi/extern
 happen that they become incompatible with each other. If the
  issues above above have been ruled out, <a href="https://github.com/kubernetes/community/tree/master/sig-storage" target="_blank">contact the sig-storage
 team</a> and/or
-<a href="https://github.com/kubernetes/community/blob/master/contributors/devel/e2e-tests.md#local-clusters" target="_blank">run the e2e test</a>:</p>
+<a href="https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/e2e-tests.md#local-clusters" target="_blank">run the e2e test</a>:</p>
 <pre><code>go run hack/e2e.go -- --provider=local --test --test_args=&quot;--ginkgo.focus=Feature:CSI&quot;
 </code></pre>
                                 

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -41,7 +41,7 @@ The external components images are under active development. It can
 happen that they become incompatible with each other. If the
  issues above above have been ruled out, [contact the sig-storage
 team](https://github.com/kubernetes/community/tree/master/sig-storage) and/or
-[run the e2e test](https://github.com/kubernetes/community/blob/master/contributors/devel/e2e-tests.md#local-clusters):
+[run the e2e test](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/e2e-tests.md#local-clusters):
 ```
 go run hack/e2e.go -- --provider=local --test --test_args="--ginkgo.focus=Feature:CSI"
 ```


### PR DESCRIPTION
/kind bug
/sig docs

the error url is:
https://github.com/kubernetes/community/blob/master/contributors/devel/e2e-tests.md

the right url is:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/e2e-tests.md