### PR TITLE
Update snapshot docs for beta

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -3,6 +3,8 @@
 - [Introduction](introduction.md)
 - [Developing a CSI Driver for Kubernetes](developing.md)
     - [Kubernetes Changelog](kubernetes-changelog.md)
+    - [Kubernetes Cluster Controllers](kubernetes-cluster-controllers.md)
+        - [Snapshot Controller](snapshot-controller.md)
     - [Sidecar Containers](sidecar-containers.md)
         - [Kubernetes Compatibility](kubernetes-compatibility.md)
         - [external-attacher](external-attacher.md)

--- a/book/src/external-snapshotter.md
+++ b/book/src/external-snapshotter.md
@@ -4,34 +4,61 @@
 
 **Git Repository:** [https://github.com/kubernetes-csi/external-snapshotter](https://github.com/kubernetes-csi/external-snapshotter)
 
-**Status:** Alpha
+**Status:** v2.0.0 and higher is Beta; version below v2.0.0 is Alpha
+
+### CSI External-Snapshotter Sidecar
 
 Latest stable release | Branch | Min CSI Version | Max CSI Version | Container Image | Min K8s Version | Max K8s Version | Recommended K8s Version
 --|--|--|--|--|--|--|--
-[external-snapshotter v1.2.2](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v1.2.2) | [release-1.2](https://github.com/kubernetes-csi/external-snapshotter/tree/release-1.2) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | quay.io/k8scsi/csi-snapshotter:v1.2.2 | v1.13 | - | v1.14
-[external-snapshotter v0.4.1](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v0.4.1) | [release-0.4](https://github.com/kubernetes-csi/external-snapshotter/tree/release-0.4) | [v0.3.0](https://github.com/container-storage-interface/spec/releases/tag/v0.3.0) | [v0.3.0](https://github.com/container-storage-interface/spec/releases/tag/v0.3.0) | quay.io/k8scsi/csi-snapshotter:v0.4.1 | v1.10 | -v1.16 | v1.10
+[external-snapshotter v2.0.1](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v2.0.1) | [release-2.0](https://github.com/kubernetes-csi/external-snapshotter/tree/release-2.0) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | quay.io/k8scsi/csi-snapshotter:v2.0.1 | v1.17 | - | v1.17
+[external-snapshotter v1.2.2](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v1.2.2) | [release-1.2](https://github.com/kubernetes-csi/external-snapshotter/tree/release-1.2) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | quay.io/k8scsi/csi-snapshotter:v1.2.2 | v1.13 | v1.16 | v1.14
+[external-snapshotter v0.4.2](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v0.4.2) | [release-0.4](https://github.com/kubernetes-csi/external-snapshotter/tree/release-0.4) | [v0.3.0](https://github.com/container-storage-interface/spec/releases/tag/v0.3.0) | [v0.3.0](https://github.com/container-storage-interface/spec/releases/tag/v0.3.0) | quay.io/k8scsi/csi-snapshotter:v0.4.2 | v1.12 | v1.16 | v1.12
 
 Definitions of the min/max/recommended Kubernetes versions can be found on the
 [sidecar page](sidecar-containers.md#versioning)
 
-## Description
+To use the snapshot beta feature, a snapshot controller is also required. For more information, see [this snapshot-controller page](snapshot-controller.md).
+
+## Snapshot Beta
+
+### Description
+
+In the Beta version, the snapshot controller will be watching the Kubernetes API server for `VolumeSnapshot` and `VolumeSnapshotContent` CRD objects. The CSI `external-snapshotter` sidecar only watches the Kubernetes API server for `VolumeSnapshotContent` CRD objects. The CSI `external-snapshotter` sidecar is also responsible for calling the CSI RPCs CreateSnapshot, DeleteSnapshot, and ListSnapshots.
+
+For detailed snapshot beta design changes, see the design doc [here](https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/20190709-csi-snapshot.md).
+
+For detailed information about volume snapshot and restore functionality, see [Volume Snapshot & Restore](snapshot-restore-feature.md).
+
+### Usage
+
+CSI drivers that support provisioning volume snapshots and the ability to provision new volumes using those snapshots should use this sidecar container, and advertise the CSI `CREATE_DELETE_SNAPSHOT` controller capability.
+
+For detailed information (binary parameters, RBAC rules, etc.), see [https://github.com/kubernetes-csi/external-snapshotter/blob/release-2.0/README.md](https://github.com/kubernetes-csi/external-snapshotter/blob/release-2.0/README.md).
+
+### Deployment
+
+The CSI `external-snapshotter` is deployed as a sidecar controller. See [deployment section](deploying.md) for more details.
+
+For an example deployment, see [this example](https://github.com/kubernetes-csi/external-snapshotter/tree/release-2.0/deploy/kubernetes/setup-csi-snapshotter.yaml) which deploys `external-snapshotter` and `external-provisioner` with the Hostpath CSI driver.
+
+## Snapshot Alpha
+
+### Description
 
 The CSI `external-snapshotter` is a sidecar container that watches the Kubernetes API server for `VolumeSnapshot` and `VolumeSnapshotContent` CRD objects.
 
 The creation of a new `VolumeSnapshot` object referencing a `SnapshotClass` CRD object corresponding to this driver causes the sidecar container to trigger a `CreateSnapshot` operation against the specified CSI endpoint to provision a new snapshot. When a new snapshot is successfully provisioned, the sidecar container creates a Kubernetes `VolumeSnapshotContent` object to represent the new snapshot.
 
-The deletion of a `VolumeSnapshot` object bound to a `VolumeSnapshotContent` corresponding to this driver with a `delete` reclaim policy causes the sidecar container to trigger a `DeleteSnapshot` operation against the specified CSI endpoint to delete the snapshot. Once the snapshot is successfully deleted, the sidecar container also deletes the `VolumeSnapshotContent` object representing the snapshot.
+The deletion of a `VolumeSnapshot` object bound to a `VolumeSnapshotContent` corresponding to this driver with a `delete` deletion policy causes the sidecar container to trigger a `DeleteSnapshot` operation against the specified CSI endpoint to delete the snapshot. Once the snapshot is successfully deleted, the sidecar container also deletes the `VolumeSnapshotContent` object representing the snapshot.
 
-For detailed information about volume snapshot and restore functionality, see [Volume Snapshot & Restore](snapshot-restore-feature.md).
-
-## Usage
+### Usage
 
 CSI drivers that support provisioning volume snapshots and the ability to provision new volumes using those snapshots should use this sidecar container, and advertise the CSI `CREATE_DELETE_SNAPSHOT` controller capability.
 
-For detailed information (binary parameters, RBAC rules, etc.), see [https://github.com/kubernetes-csi/external-snapshotter/blob/master/README.md](https://github.com/kubernetes-csi/external-snapshotter/blob/master/README.md).
+For detailed information (binary parameters, RBAC rules, etc.), see [https://github.com/kubernetes-csi/external-snapshotter/blob/release-1.2/README.md](https://github.com/kubernetes-csi/external-snapshotter/blob/release-1.2/README.md).
 
-## Deployment
+### Deployment
 
 The CSI `external-snapshotter` is deployed as a controller. See [deployment section](deploying.md) for more details.
 
-For an example deployment, see [this example](https://github.com/kubernetes-csi/external-snapshotter/blob/release-1.2/deploy/kubernetes/setup-csi-snapshotter.yaml) which deploys `external-snapshotter` and `external-provisioner` with the Hostpath CSI driver.
+For an example deployment, see [this example](https://github.com/kubernetes-csi/external-snapshotter/tree/release-1.2/deploy/kubernetes/setup-csi-snapshotter.yaml) which deploys `external-snapshotter` and `external-provisioner` with the Hostpath CSI driver.

--- a/book/src/kubernetes-cluster-controllers.md
+++ b/book/src/kubernetes-cluster-controllers.md
@@ -1,0 +1,7 @@
+# Kubernetes Cluster Controllers
+
+The Kubernetes cluster controllers are responsible for managing snapshot objects and operations across multiple CSI drivers, so they should be bundled and deployed by the Kubernetes distributors as part of their Kubernetes cluster management process (independent of any CSI Driver).
+
+The Kubernetes development team maintains the following Kubernetes cluster controllers:
+
+* [snapshot-controller](snapshot-controller.md)

--- a/book/src/snapshot-controller.md
+++ b/book/src/snapshot-controller.md
@@ -1,0 +1,51 @@
+# Snapshot Controller
+
+## Status and Releases
+
+**Git Repository:** [https://github.com/kubernetes-csi/external-snapshotter](https://github.com/kubernetes-csi/external-snapshotter)
+
+**Status:** v2.0.0 and higher is Beta
+
+### Snapshot Controller
+
+When Volume Snapshot is promoted to Beta in Kubernetes 1.17, the CSI external-snapshotter sidecar controller is split into two controllers: a snapshot-controller and a CSI external-snapshotter sidecar. See the following table for snapshot-controller release information.
+
+Latest stable release | Branch | Min CSI Version | Max CSI Version | Container Image | Min K8s Version | Max K8s Version | Recommended K8s Version
+--|--|--|--|--|--|--|--
+[external-snapshotter v2.0.1](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v2.0.1) | [release-2.0](https://github.com/kubernetes-csi/external-snapshotter/tree/release-2.0) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | quay.io/k8scsi/snapshot-controller:v2.0.1 | v1.17 | - | v1.17
+
+For more information on the beta version of the CSI external-snapshotter sidecar, see [this external-snapshotter page](external-snapshotter.md).
+
+## Description
+
+In the Beta version, the snapshot controller will be watching the Kubernetes API server for `VolumeSnapshot` and `VolumeSnapshotContent` CRD objects. The CSI `external-snapshotter` sidecar only watches the Kubernetes API server for `VolumeSnapshotContent` CRD objects. The snapshot controller will be creating the `VolumeSnapshotContent` CRD object which triggers the CSI `external-snapshotter` sidecar to create a snapshot on the storage system.
+
+For detailed snapshot beta design changes, see the design doc [here](https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/20190709-csi-snapshot.md).
+
+For detailed information about volume snapshot and restore functionality, see [Volume Snapshot & Restore](snapshot-restore-feature.md).
+
+For detailed information (binary parameters, RBAC rules, etc.), see [https://github.com/kubernetes-csi/external-snapshotter/blob/release-2.0/README.md](https://github.com/kubernetes-csi/external-snapshotter/blob/release-2.0/README.md).
+
+## Deployment
+
+Kubernetes distributors should bundle and deploy the controller and CRDs as part of their Kubernetes cluster management process (independent of any CSI Driver).
+
+If your cluster does not come pre-installed with the correct components, you may manually install these components by executing the following steps.
+
+Install Snapshot Beta CRDs per cluster:
+
+```
+kubectl create -f  https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-2.0/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+
+kubectl create -f  https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-2.0/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+
+kubectl create -f  https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-2.0/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+```
+
+Install Snapshot Controller per cluster:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-2.0/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-2.0/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+```

--- a/book/src/snapshot-restore-feature.md
+++ b/book/src/snapshot-restore-feature.md
@@ -2,10 +2,11 @@
 
 ## Status
 
-Status | Min K8s Version | Max K8s Version | external-snapshotter Version | external-provisioner Version
---|--|--|--|--
-Alpha | 1.12 | 1.12 | 0.4 | 0.4
-Alpha | 1.13 | - | 1.0+ | 1.0+
+Status | Min K8s Version | Max K8s Version | snapshot-controller Version | CSI external-snapshotter sidecar Version | external-provisioner Version
+--|--|--|--|--|--
+Alpha | 1.12 | 1.12 | | 0.4.0 <= version < 1.0 | 0.4.1 <= version < 1.0
+Alpha | 1.13 | 1.16 | | 1.0.1 <= version < 2.0 | 1.0.1 <= version < 1.5
+Beta  | 1.17 | - | 2.0+ | 2.0+ | 1.5+
 
 ## Overview
 
@@ -15,6 +16,8 @@ Kubernetes CSI currently enables CSI Drivers to expose the following functionali
 
 1. Creation and deletion of volume snapshots via [Kubernetes native API](https://kubernetes.io/docs/concepts/storage/volume-snapshots/). 
 2. Creation of new volumes pre-populated with the data from a snapshot via Kubernetes [dynamic volume provisioning](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/).
+
+Note: Documentation under https://kubernetes.io/docs is for the latest Kubernetes release. Documentation for earlier releases are stored in different location. For example, this is the documentation location for [v1.16](https://v1-16.docs.kubernetes.io/docs/concepts/storage/volume-snapshots/).
 
 ## Implementing Snapshot & Restore Functionality in Your CSI Driver
 
@@ -27,30 +30,40 @@ For details,  see the [CSI spec](https://github.com/container-storage-interface/
 
 ## Sidecar Deployment
 
-The Kubernetes CSI development team maintains the [external-snapshotter](external-snapshotter.md) Kubernetes CSI [Sidecar Containers](sidecar-containers.md). This sidecar container implements the logic for watching the Kubernetes API for snapshot objects and issuing the appropriate CSI snapshot calls against a CSI endpoint. For more details, see [external-snapshotter documentation](external-snapshotter.md).
+The Kubernetes CSI development team maintains the [external-snapshotter](external-snapshotter.md) Kubernetes CSI [Sidecar Containers](sidecar-containers.md). This sidecar container implements the logic for watching the Kubernetes API objects and issuing the appropriate CSI snapshot calls against a CSI endpoint. For more details, see [external-snapshotter documentation](external-snapshotter.md).
 
-## Snapshot APIs
+## Snapshot Beta
+### Snapshot APIs
 
-Similar to the API for managing [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/), the Kubernetes Volume Snapshots introduce three new API objects for managing snapshots: `VolumeSnapshot`, `VolumeSnapshotContent`, and `VolumeSnapshotClass`. See [Kubernetes Snapshot documentation](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) for more details.
+With the promotion of Volume Snapshot to beta, the feature is now enabled by default on standard Kubernetes deployments instead of being opt-in. This involves a revamp of volume snapshot APIs.
 
-Unlike the core Kubernetes Persistent Volume objects, these Snapshot objects are defined as [Custom Resource Definitions](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#create-a-customresourcedefinition) (CRDs). This is because the Kubernetes project is moving away from having resource types pre-defined in the API server. This allows the API server to be reused for projects other than Kubernetes, and consumers (like Kubernetes) simply install the resource types they require as CRDs. Because the Snapshot API types are not built in to Kubernetes, they must be installed prior to use.
+The schema definition for the custom resources (CRs) can be found [here](https://github.com/kubernetes-csi/external-snapshotter/blob/release-2.0/pkg/apis/volumesnapshot/v1beta1/types.go). The CRDs are no longer automatically deployed by the sidecar. They should be installed by the Kubernetes distributions.
 
-The CRDs are [automatically deployed](https://github.com/kubernetes-csi/external-snapshotter/blob/master/cmd/csi-snapshotter/create_crd.go#L29) by the CSI [external-snapshotter](external-snapshotter.md) sidecar.
+#### Hightlights in the snapshot v1beta1 APIs
 
-The schema definition for the custom resources (CRs) can be found here: [https://github.com/kubernetes-csi/external-snapshotter/blob/master/pkg/apis/volumesnapshot/v1alpha1/types.go](https://github.com/kubernetes-csi/external-snapshotter/blob/master/pkg/apis/volumesnapshot/v1alpha1/types.go)
+* DeletionPolicy is a required field in both VolumeSnapshotClass and VolumeSnapshotContent. This way the user has to explicitly specify it, leaving no room for confusion.
+* VolumeSnapshotSpec has a required Source field. Source may be either a PersistentVolumeClaimName (if dynamically provisioning a snapshot) or VolumeSnapshotContentName (if pre-provisioning a snapshot).
+* VolumeSnapshotContentSpec has a required Source field. This Source may be either a VolumeHandle (if dynamically provisioning a snapshot) or a SnapshotHandle (if pre-provisioning volume snapshots).
+* VolumeSnapshot contains a Status to indicate the current state of the volume snapshot. It has a field BoundVolumeSnapshotContentName to indicate the VolumeSnapshot object is bound to a VolumeSnapshotContent.
+* VolumeSnapshotContent contains a Status to indicate the current state of the volume snapshot content. It has a field SnapshotHandle to indicate that the VolumeSnapshotContent represents a snapshot on the storage system.
 
-In addition to these new CRD objects, a new, alpha `DataSource` field has been added to the `PersistentVolumeClaim` object. This new field enables dynamic provisioning of new volumes that are automatically pre-populated with data from an existing snapshot.
+### Controller Split
 
-## Kubernetes Cluster Setup
-Since volume snapshot is an alpha feature in Kubernetes v1.12, you need to enable a new alpha feature gate called `VolumeSnapshotDataSource` in the Kubernetes master.
+* The CSI external-snapshotter sidecar is split into two controllers, a snapshot controller and a CSI external-snapshotter sidecar.
 
-```
---feature-gates=VolumeSnapshotDataSource=true
-```
+The snapshot controller is deployed by the Kubernetes distributions and is responsible for watching the VolumeSnapshot CRD objects and manges the creation and deletion lifecycle of snapshots.
 
-## Test Snapshot Feature
+The CSI external-snapshotter sidecar watches Kubernetes VolumeSnapshotContent CRD objects and triggers CreateSnapshot/DeleteSnapshot against a CSI endpoint.
 
-Use the following [example yaml files](https://github.com/kubernetes-csi/external-snapshotter/tree/master/examples/kubernetes) to test the snapshot feature.
+### Kubernetes Cluster Setup
+
+Volume snapshot is promoted to beta in Kubernetes 1.17 so the `VolumeSnapshotDataSource` feature gate is enabled by default.
+
+See the Deployment section of [Snapshot Controller](snapshot-controller.md) on how to set up the snapshot controller and CRDs.
+
+### Test Snapshot Feature
+
+To test snapshot Beta version, use the following [example yaml files](https://github.com/kubernetes-csi/external-snapshotter/tree/release-2.0/examples/kubernetes).
 
 Create a _StorageClass_:
 ```
@@ -77,7 +90,65 @@ Create a _PVC_ from a _VolumeSnapshot_:
 kuberctl create -f restore.yaml
 ```
 
-### PersistentVolumeClaim not Bound
+#### PersistentVolumeClaim not Bound
+
+If a `PersistentVolumeClaim` is not bound, the attempt to create a volume snapshot from that `PersistentVolumeClaim` will fail. No retries will be attempted. An event will be logged to indicate that the `PersistentVolumeClaim` is not bound.
+
+Note that this could happen if the `PersistentVolumeClaim` spec and the `VolumeSnapshot` spec are in the same YAML file. In this case, when the `VolumeSnapshot` object is created, the `PersistentVolumeClaim` object is created but volume creation is not complete and therefore the `PersistentVolumeClaim` is not yet bound. You must wait until the `PersistentVolumeClaim` is bound and then create the snapshot.
+
+Note: This behavior is planned to be changed as we are going to fix the timeout issue reported [here](https://github.com/kubernetes-csi/external-snapshotter/issues/134).
+
+## Snapshot Alpha
+### Snapshot APIs
+
+Similar to the API for managing [Kubernetes Persistent Volumes](https://v1-16.docs.kubernetes.io/docs/concepts/storage/persistent-volumes/), the Kubernetes Volume Snapshots introduce three new API objects for managing snapshots: `VolumeSnapshot`, `VolumeSnapshotContent`, and `VolumeSnapshotClass`. See [Kubernetes Snapshot documentation](https://v1-16.docs.kubernetes.io/docs/concepts/storage/volume-snapshots/) for more details.
+
+Unlike the core Kubernetes Persistent Volume objects, these Snapshot objects are defined as [Custom Resource Definitions](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#create-a-customresourcedefinition) (CRDs). This is because the Kubernetes project is moving away from having resource types pre-defined in the API server. This allows the API server to be reused for projects other than Kubernetes, and consumers (like Kubernetes) simply install the resource types they require as CRDs. Because the Snapshot API types are not built in to Kubernetes, they must be installed prior to use.
+
+The CRDs are [automatically deployed](https://github.com/kubernetes-csi/external-snapshotter/blob/release-1.2/cmd/csi-snapshotter/create_crd.go#L29) by the CSI external-snapshotter sidecar. See Alpha section of the sidecar doc [here](external-snapshotter.md).
+
+The schema definition for the custom resources (CRs) can be found [here](https://github.com/kubernetes-csi/external-snapshotter/blob/release-1.2/pkg/apis/volumesnapshot/v1alpha1/types.go).
+
+In addition to these new CRD objects, a new, alpha `DataSource` field has been added to the `PersistentVolumeClaim` object. This new field enables dynamic provisioning of new volumes that are automatically pre-populated with data from an existing snapshot.
+
+### Kubernetes Cluster Setup
+
+Since volume snapshot is an alpha feature in Kubernetes v1.12 to v1.16, you need to enable a new alpha feature gate called `VolumeSnapshotDataSource` in the Kubernetes master.
+
+```
+--feature-gates=VolumeSnapshotDataSource=true
+```
+
+### Test Snapshot Feature
+
+To test snapshot Alpha version, use the following [example yaml files](https://github.com/kubernetes-csi/external-snapshotter/tree/release-1.2/examples/kubernetes).
+
+Create a _StorageClass_:
+```
+kubectl create -f storageclass.yaml
+```
+
+Create a _PVC_:
+```
+kubectl create -f pvc.yaml
+```
+
+Create a _VolumeSnapshotClass_:
+```
+kubectl create -f snapshotclass.yaml
+```
+
+Create a _VolumeSnapshot_:
+```
+kubectl create -f snapshot.yaml
+```
+
+Create a _PVC_ from a _VolumeSnapshot_:
+```
+kuberctl create -f restore.yaml
+```
+
+#### PersistentVolumeClaim not Bound
 
 If a `PersistentVolumeClaim` is not bound, the attempt to create a volume snapshot from that `PersistentVolumeClaim` will fail. No retries will be attempted. An event will be logged to indicate that the `PersistentVolumeClaim` is not bound.
 


### PR DESCRIPTION
This PR updates snapshot CSI docs for beta.

Note: The deployment section (https://github.com/kubernetes-csi/csi-driver-host-path#deployment) needs to be modified.  That should be in a separate PR.


```release-note
NONE
```

