### PR TITLE
Updating CSIDriver features for GA

### DIFF
--- a/book/src/pod-info.md
+++ b/book/src/pod-info.md
@@ -6,7 +6,8 @@ Status | Min K8s Version | Max K8s Version | cluster-driver-registrar Version
 --|--|--|--
 Alpha | 1.12 | 1.12 | 0.4
 Alpha | 1.13 | 1.13 | 1.0
-Beta | 1.14 | - | n/a
+Beta | 1.14 | 1.17 | n/a
+GA | 1.18 | - | n/a
 
 # Overview
 
@@ -23,7 +24,7 @@ Specifically the `podInfoOnMount` field instructs Kubernetes that the CSI driver
 For example, the existence of the following object would cause Kubernetes to add pod information at mount time to the `NodePublishVolumeRequest.volume_context` map.
 
 ```
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: testcsidriver.example.com

--- a/book/src/skip-attach.md
+++ b/book/src/skip-attach.md
@@ -6,7 +6,8 @@ Status | Min K8s Version | Max K8s Version | cluster-driver-registrar Version
 --|--|--|--
 Alpha | 1.12 | 1.12 | 0.4
 Alpha | 1.13 | 1.13 | 1.0
-Beta | 1.14 | - | n/a
+Beta | 1.14 | 1.17 | n/a
+GA | 1.18 | - | n/a
 
 # Overview
 
@@ -25,7 +26,7 @@ Specifically the `attachRequired` field instructs Kubernetes to skip any attach 
 For example, the existence of the following object would cause Kubernetes to skip attach operations for all CSI Driver `testcsidriver.example.com` volumes.
 
 ```
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: testcsidriver.example.com


### PR DESCRIPTION
CSIDrivers were moved to GA as of kubernetes/kubernetes#84814 . This PR updates the associated features (PodInfo and SkipAttach) to indicate this new status, along with removing the beta references in examples.

Release note was included https://github.com/kubernetes-csi/docs/pull/283 , let me know if I need one for this PR as well.