### PR TITLE
Remove feature gate enablement in sidecar mention for topology.

### DIFF
--- a/book/src/topology.md
+++ b/book/src/topology.md
@@ -44,12 +44,7 @@ In the StorageClass object, both `volumeBindingMode` values of `Immediate` and
 ## Sidecar Deployment
 
 The topology feature requires the
-[external-provisioner](external-provisioner.md) sidecar with the
-Topology feature gate enabled:
-
-```
---feature-gates=Topology=true
-```
+[external-provisioner](external-provisioner.md) sidecar.
 
 ## Kubernetes Cluster Setup
 


### PR DESCRIPTION
Considering this feature is GA, we dont need to mention anymore
that this feature gate has to be enabled.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>