### PR TITLE
Outline csi-prefixed parameters included by --extra-create-metadata

### DIFF
--- a/book/src/external-provisioner.md
+++ b/book/src/external-provisioner.md
@@ -45,7 +45,7 @@ Cloning is also implemented by specifying a `kind:` of type `PersistentVolumeCla
 
 When provisioning a new volume, the CSI `external-provisioner` sets the `map<string, string> parameters` field in the CSI `CreateVolumeRequest` call to the key/values specified in the `StorageClass` it is handling.
 
-The CSI `external-provisioner` (v1.0.1+) also reserves the parameter keys prefixed with `csi.storage.k8s.io/`. Any keys prefixed with `csi.storage.k8s.io/` are not passed to the CSI driver as an opaque `parameter`.
+The CSI `external-provisioner` (v1.0.1+) also reserves the parameter keys prefixed with `csi.storage.k8s.io/`. Any `StorageClass` keys prefixed with `csi.storage.k8s.io/` are not passed to the CSI driver as an opaque `parameter`.
 
 The following reserved `StorageClass` parameter keys trigger behavior in the CSI `external-provisioner`:
 
@@ -77,6 +77,17 @@ parameters:
   csi.storage.k8s.io/provisioner-secret-name: mysecret
   csi.storage.k8s.io/provisioner-secret-namespace: mynamespace
 ```
+
+### PersistentVolumeClaim and PersistentVolume Parameters
+
+The CSI `external-provisioner` (v1.6.0+) introduces the `--extra-create-metadata` flag, which automatically sets the following `map<string, string> parameters` in the CSI `CreateVolumeRequest`:
+
+* `csi.storage.k8s.io/pvc/name`
+* `csi.storage.k8s.io/pvc/namespace`
+* `csi.storage.k8s.io/pv/name`
+
+These parameters are not part of the `StorageClass`, but are internally generated using the name and namespace of the source `PersistentVolumeClaim` and `PersistentVolume`.
+
 ## Usage
 
 CSI drivers that support dynamic volume provisioning should use this sidecar container, and advertise the CSI `CREATE_DELETE_VOLUME` controller capability.

--- a/book/src/external-snapshotter.md
+++ b/book/src/external-snapshotter.md
@@ -23,6 +23,31 @@ To use the snapshot beta feature, a snapshot controller is also required. For mo
 
 In the Beta version, the snapshot controller will be watching the Kubernetes API server for `VolumeSnapshot` and `VolumeSnapshotContent` CRD objects. The CSI `external-snapshotter` sidecar only watches the Kubernetes API server for `VolumeSnapshotContent` CRD objects. The CSI `external-snapshotter` sidecar is also responsible for calling the CSI RPCs CreateSnapshot, DeleteSnapshot, and ListSnapshots.
 
+#### VolumeSnapshotClass Parameters
+
+When provisioning a new volume snapshot, the CSI `external-snapshotter` sets the `map<string, string> parameters` field in the CSI `CreateSnapshotRequest` call to the key/values specified in the `VolumeSnapshotClass` it is handling.
+
+The CSI `external-snapshotter` also reserves the parameter keys prefixed with `csi.storage.k8s.io/`. Any `VolumeSnapshotClass` keys prefixed with `csi.storage.k8s.io/` are not passed to the CSI driver as an opaque `parameter`.
+
+The following reserved `VolumeSnapshotClass` parameter keys trigger behavior in the CSI `external-snapshotter`:
+
+* `csi.storage.k8s.io/snapshotter-secret-name` (v1.0.1+)
+* `csi.storage.k8s.io/snapshotter-secret-namespace` (v1.0.1+)
+* `csi.storage.k8s.io/snapshotter-list-secret-name` (v2.1.0+)
+* `csi.storage.k8s.io/snapshotter-list-secret-namespace` (v2.1.0+)
+
+For more information on how secrets are handled see [Secrets & Credentials](secrets-and-credentials.md).
+
+#### VolumeSnapshot and VolumeSnapshotContent Parameters
+
+The CSI `external-snapshotter` (v4.0.0+) introduces the `--extra-create-metadata` flag, which automatically sets the following `map<string, string> parameters` in the CSI `CreateSnapshotRequest`:
+
+* `csi.storage.k8s.io/volumesnapshot/name`
+* `csi.storage.k8s.io/volumesnapshot/namespace`
+* `csi.storage.k8s.io/volumesnapshotcontent/name`
+
+These parameters are internally generated using the name and namespace of the source `VolumeSnapshot` and `VolumeSnapshotContent`.
+
 For detailed snapshot beta design changes, see the design doc [here](https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/177-volume-snapshot/README.md).
 
 For detailed information about volume snapshot and restore functionality, see [Volume Snapshot & Restore](snapshot-restore-feature.md).


### PR DESCRIPTION
## Outline

* Updates external-provisioner and external-snapshotter docs to clarify behavior around prefixed parameter keys and include keys added by the `--extra-create-metadata` flag.

## Resources

* [Commit that introduces the `--extra-create-metadata` parameter keys to the external-provisioner, which appears to be first available in v1.6.0](https://github.com/kubernetes-csi/external-provisioner/commit/53f0949f60eda07d2df3d4fbe37e95ff51ba7408).
* [Commit that introduces the four reserved `VolumeSnapshotClass` parameter keys, which appears to be first available in release v2.1.0](https://github.com/kubernetes-csi/external-snapshotter/commit/0a1579d0f2a9b01b08b3f502ead4d270fc2dc195).
* [Open PR that adds the `--extra-create-metadata` parameter keys to the external-snapshotter](https://github.com/kubernetes-csi/external-snapshotter/pull/375).

**NOTE:** Do not merge this until the above PR is merged and a release is cut.