### PR TITLE
Move CSIVolumeFSGroupPolicy to beta

### DIFF
--- a/book/src/csi-driver-object.md
+++ b/book/src/csi-driver-object.md
@@ -30,7 +30,7 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: true
-  fsGroupPolicy: File # added in Kubernetes 1.19, this field is alpha
+  fsGroupPolicy: File # added in Kubernetes 1.19, this field is beta as of Kubernetes 1.20
   volumeLifecycleModes: # added in Kubernetes 1.16, this field is beta
     - Persistent
     - Ephemeral
@@ -61,7 +61,7 @@ These are the important fields:
   - For more information see [Pod Info on Mount](pod-info.md).
 - `fsGroupPolicy`
   - This field was added in Kubernetes 1.19 and cannot be set when using an older Kubernetes release.
-  - This field is alpha.
+  - This field is beta in Kubernetes 1.20.
   - Controls if this CSI volume driver supports volume ownership and permission changes when volumes are mounted.
   - The following modes are supported, and if not specified the default is `ReadWriteOnceWithFSType`:
     - `None`: Indicates that volumes will be mounted with no modifications, as the CSI volume driver does not support these operations.

--- a/book/src/support-fsgroup.md
+++ b/book/src/support-fsgroup.md
@@ -4,7 +4,8 @@
 
 Status | Min K8s Version | Max K8s Version 
 --|--|--
-Alpha | 1.19 | -
+Alpha | 1.19 | 1.19
+Beta | 1.20 | -
 
 # Overview
 


### PR DESCRIPTION
The CSIVolumeFSGroupPolicy feature is moving to beta in k8s 1.20. This PR updates the documentation accordingly.

PRs:
kubernetes/kubernetes#95739

Issues:
kubernetes/enhancements#1682

```release-note
The CSIVolumeFSGroupPolicy field has moved to beta, allowing storage.k8s.io/CSIDrivers to specify if they support modifying volume ownership and permissions when volumes are being mounted.
```