### PR TITLE
Fix accessMode in CSIDriver doc

### DIFF
--- a/book/src/csi-driver-object.md
+++ b/book/src/csi-driver-object.md
@@ -67,7 +67,7 @@ These are the important fields:
     - `None`: Indicates that volumes will be mounted with no modifications, as the CSI volume driver does not support these operations.
     - `File`: Indicates that the CSI volume driver supports volume ownership and permission change via fsGroup, and Kubernetes may use fsGroup to change permissions and ownership of the volume to match user requested fsGroup in the pod's SecurityPolicy regardless of fstype or access mode.
     - `ReadWriteOnceWithFSType`: Indicates that volumes will be examined to determine if volume ownership and permissions should be modified to match the pod's security policy.
-      Changes will only occur if the `fsType` is defined and the persistent volume's `accessModes` contains `ReadWriteOnly`.
+      Changes will only occur if the `fsType` is defined and the persistent volume's `accessModes` contains `ReadWriteOnce`.
       This is the default behavior if no other FSGroupPolicy is defined.
   - For more information see [CSI Driver fsGroup Support](support-fsgroup.md).
 - `volumeLifecycleModes`

--- a/book/src/support-fsgroup.md
+++ b/book/src/support-fsgroup.md
@@ -38,7 +38,7 @@ spec:
     * `None`: Indicates that volumes will be mounted with no modifications, as the CSI volume driver does not support these operations.
     * `File`: Indicates that the CSI volume driver supports volume ownership and permission change via fsGroup, and Kubernetes may use fsGroup to change permissions and ownership of the volume to match user requested fsGroup in the pod's SecurityPolicy regardless of fstype or access mode.
     * `ReadWriteOnceWithFSType`: Indicates that volumes will be examined to determine if volume ownership and permissions should be modified to match the pod's security policy. 
-      Changes will only occur if the `fsType` is defined and the persistent volume's `accessModes` contains `ReadWriteOnly`. .
+      Changes will only occur if the `fsType` is defined and the persistent volume's `accessModes` contains `ReadWriteOnce`. .
 
 If undefined, `fsGroupPolicy` will default to `ReadWriteOnceWithFSType`, keeping the previous behavior.
 


### PR DESCRIPTION
According to the Kubernetes [doc](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) `ReadWriteOnly` does not exist. I suppose it should be `ReadWriteOnce`.