### PR TITLE
build: use custom SSH key

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: push
+name: publish
 
 # Controls when the workflow will run
 on:
@@ -31,3 +31,9 @@ jobs:
         with:
           branch: gh-pages
           folder: docs
+          git-config-name: GitHub Actions
+          git-config-email: github-actions@kubernetes-csi
+          # This secret was created in the repo's settings under "Secrets".
+          # It contains an SSH private key created specifically for this job.
+          # The corresponding public key was added to the repo's deploy keys.
+          ssh-key: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
Using the default failed the CNCF's CLA check:
```
  remote: error: GH006: Protected branch update failed for refs/heads/gh-pages.
  remote: error: Required status check "cla/linuxfoundation" is expected.
  To https://github.com/kubernetes-csi/docs.git
   ! [remote rejected] github-pages-deploy-action/zypejdthm -> gh-pages (protected branch hook declined)
```

This did not happen for TravisCI which authenticated via a custom
SSH key, so the same approach is now also used for GitHub Actions.