### PR TITLE
Update sidecar releases to the latest versions

### DIFF
--- a/book/src/external-attacher.md
+++ b/book/src/external-attacher.md
@@ -10,14 +10,16 @@
 
 Latest stable release | Branch | Min CSI Version | Max CSI Version | Container Image | [Min K8s Version](kubernetes-compatibility.md#minimum-version) | [Max K8s Version](kubernetes-compatibility.md#maximum-version) | [Recommended K8s Version](kubernetes-compatibility.md#recommended-version) |
 --|--|--|--|--|--|--|--
+[external-attacher v3.3.0](https://github.com/kubernetes-csi/external-attacher/releases/tag/v3.3.0) | [release-3.3](https://github.com/kubernetes-csi/external-attacher/tree/release-3.3) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | k8s.gcr.io/sig-storage/csi-attacher:v3.3.0 | v1.17 | - | v1.22
 [external-attacher v3.2.1](https://github.com/kubernetes-csi/external-attacher/releases/tag/v3.2.1) | [release-3.2](https://github.com/kubernetes-csi/external-attacher/tree/release-3.2) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | k8s.gcr.io/sig-storage/csi-attacher:v3.2.1 | v1.17 | - | v1.17
 [external-attacher v3.1.0](https://github.com/kubernetes-csi/external-attacher/releases/tag/v3.1.0) | [release-3.1](https://github.com/kubernetes-csi/external-attacher/tree/release-3.1) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | k8s.gcr.io/sig-storage/csi-attacher:v3.1.0 | v1.17 | - | v1.17
-[external-attacher v3.0.2](https://github.com/kubernetes-csi/external-attacher/releases/tag/v3.0.2) | [release-3.0](https://github.com/kubernetes-csi/external-attacher/tree/release-3.0) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | k8s.gcr.io/sig-storage/csi-attacher:v3.0.2 | v1.17 | - | v1.17
+
 
 ### Unsupported Versions
 
 Latest stable release | Branch | Min CSI Version | Max CSI Version | Container Image | [Min K8s Version](kubernetes-compatibility.md#minimum-version) | [Max K8s Version](kubernetes-compatibility.md#maximum-version) | [Recommended K8s Version](kubernetes-compatibility.md#recommended-version) |
 --|--|--|--|--|--|--|--
+[external-attacher v3.0.2](https://github.com/kubernetes-csi/external-attacher/releases/tag/v3.0.2) | [release-3.0](https://github.com/kubernetes-csi/external-attacher/tree/release-3.0) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | k8s.gcr.io/sig-storage/csi-attacher:v3.0.2 | v1.17 | - | v1.17
 [external-attacher v2.2.0](https://github.com/kubernetes-csi/external-attacher/releases/tag/v2.2.0) | [release-2.2](https://github.com/kubernetes-csi/external-attacher/tree/release-2.2) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | quay.io/k8scsi/csi-attacher:v2.2.0 | v1.14 | - | v1.17
 [external-attacher v2.1.0](https://github.com/kubernetes-csi/external-attacher/releases/tag/v2.1.0) | [release-2.1](https://github.com/kubernetes-csi/external-attacher/tree/release-2.1) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | quay.io/k8scsi/csi-attacher:v2.1.0 | v1.14 | - | v1.17
 [external-attacher v2.0.0](https://github.com/kubernetes-csi/external-attacher/releases/tag/v2.0.0) | [release-2.0](https://github.com/kubernetes-csi/external-attacher/tree/release-2.0) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | quay.io/k8scsi/csi-attacher:v2.0.0 | v1.14 | - | v1.15

--- a/book/src/external-resizer.md
+++ b/book/src/external-resizer.md
@@ -10,9 +10,9 @@
 
 Latest stable release | Branch | Min CSI Version | Max CSI Version | Container Image | [Min K8s Version](kubernetes-compatibility.md#minimum-version) | [Max K8s Version](kubernetes-compatibility.md#maximum-version) | [Recommended K8s Version](kubernetes-compatibility.md#recommended-version) |
 --|--|--|--|--|--|--|--
+[external-resizer v1.3.0](https://github.com/kubernetes-csi/external-resizer/tree/v1.3.0)  | [release-1.3](https://github.com/kubernetes-csi/external-resizer/tree/release-1.3) |[v1.3.0](https://github.com/container-storage-interface/spec/releases/tag/v1.2.0) | - | k8s.gcr.io/sig-storage/csi-resizer:v1.3.0  | v1.16 | - | v1.22
 [external-resizer v1.2.0](https://github.com/kubernetes-csi/external-resizer/tree/v1.2.0)  | [release-1.2](https://github.com/kubernetes-csi/external-resizer/tree/release-1.2) |[v1.2.0](https://github.com/container-storage-interface/spec/releases/tag/v1.2.0) | - | k8s.gcr.io/sig-storage/csi-resizer:v1.2.0  | v1.16 | - | v1.21
 [external-resizer v1.1.0](https://github.com/kubernetes-csi/external-resizer/tree/v1.1.0)  | [release-1.1](https://github.com/kubernetes-csi/external-resizer/tree/release-1.1) |[v1.2.0](https://github.com/container-storage-interface/spec/releases/tag/v1.2.0) | - | k8s.gcr.io/sig-storage/csi-resizer:v1.1.0  | v1.16 | - | v1.16
-[external-resizer v1.0.1](https://github.com/kubernetes-csi/external-resizer/tree/v1.0.1)  | [release-1.0](https://github.com/kubernetes-csi/external-resizer/tree/release-1.0) |[v1.2.0](https://github.com/container-storage-interface/spec/releases/tag/v1.2.0) | - | quay.io/k8scsi/csi-resizer:v1.0.1  | v1.16 | - | v1.16
 
 ### Unsupported Versions
 
@@ -21,6 +21,7 @@ Latest stable release | Branch | Min CSI Version | Max CSI Version | Container I
 [external-resizer v0.5.0](https://github.com/kubernetes-csi/external-resizer/tree/v0.5.0)  | [release-0.5](https://github.com/kubernetes-csi/external-resizer/tree/release-0.5) |[v1.2.0](https://github.com/container-storage-interface/spec/releases/tag/v1.2.0) | - | quay.io/k8scsi/csi-resizer:v0.5.0 | v1.15 | - | v1.16
 [external-resizer v0.2.0](https://github.com/kubernetes-csi/external-resizer/tree/v0.2.0)  | [release-0.2](https://github.com/kubernetes-csi/external-resizer/tree/release-0.2) |[v1.1.0](https://github.com/container-storage-interface/spec/releases/tag/v1.1.0) | - | quay.io/k8scsi/csi-resizer:v0.2.0 | v1.15 | - | v1.15
 [external-resizer v0.1.0](https://github.com/kubernetes-csi/external-resizer/tree/v0.1.0)  | [release-0.1](https://github.com/kubernetes-csi/external-resizer/tree/release-0.1) |[v1.1.0](https://github.com/container-storage-interface/spec/releases/tag/v1.1.0) | - | quay.io/k8scsi/csi-resizer:v0.1.0 | v1.14 | v1.14 | v1.14
+[external-resizer v1.0.1](https://github.com/kubernetes-csi/external-resizer/tree/v1.0.1)  | [release-1.0](https://github.com/kubernetes-csi/external-resizer/tree/release-1.0) |[v1.2.0](https://github.com/container-storage-interface/spec/releases/tag/v1.2.0) | - | quay.io/k8scsi/csi-resizer:v1.0.1  | v1.16 | - | v1.16
 
 ## Description
 

--- a/book/src/external-snapshotter.md
+++ b/book/src/external-snapshotter.md
@@ -10,9 +10,11 @@
 
 Latest stable release | Branch | Min CSI Version | Max CSI Version | Container Image | [Min K8s Version](kubernetes-compatibility.md#minimum-version) | [Max K8s Version](kubernetes-compatibility.md#maximum-version) | [Recommended K8s Version](kubernetes-compatibility.md#recommended-version) |
 --|--|--|--|--|--|--|--
+[external-snapshotter v4.2.1](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v4.2.1) | [release-4.2](https://github.com/kubernetes-csi/external-snapshotter/tree/release-4.2) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1 | v1.20 | - | v1.22
 [external-snapshotter v4.1.1](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v4.1.1) | [release-4.1](https://github.com/kubernetes-csi/external-snapshotter/tree/release-4.1) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1 | v1.20 | - | v1.20
 [external-snapshotter v4.0.0](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v4.0.0) | [release-4.0](https://github.com/kubernetes-csi/external-snapshotter/tree/release-4.0) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | k8s.gcr.io/sig-storage/csi-snapshotter:v4.0.0 | v1.20 | - | v1.20
 [external-snapshotter v3.0.3 (beta)](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v3.0.3) | [release-3.0](https://github.com/kubernetes-csi/external-snapshotter/tree/release-3.0) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3 | v1.17 | - | v1.17
+
 
 ### Unsupported Versions
 

--- a/book/src/snapshot-controller.md
+++ b/book/src/snapshot-controller.md
@@ -12,9 +12,11 @@ When Volume Snapshot is promoted to Beta in Kubernetes 1.17, the CSI external-sn
 
 Latest stable release | Branch | Min CSI Version | Max CSI Version | Container Image | [Min K8s Version](kubernetes-compatibility.md#minimum-version) | [Max K8s Version](kubernetes-compatibility.md#maximum-version) | [Recommended K8s Version](kubernetes-compatibility.md#recommended-version)
 --|--|--|--|--|--|--|--
+[external-snapshotter v4.2.1](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v4.2.1) | [release-4.2](https://github.com/kubernetes-csi/external-snapshotter/tree/release-4.2) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | k8s.gcr.io/sig-storage/snapshot-controller:v4.2.1 | v1.20 | - | v1.22
 [external-snapshotter v4.1.1](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v4.1.1) | [release-4.1](https://github.com/kubernetes-csi/external-snapshotter/tree/release-4.1) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | k8s.gcr.io/sig-storage/snapshot-controller:v4.1.1 | v1.20 | - | v1.20
 [external-snapshotter v4.0.0](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v4.0.0) | [release-4.0](https://github.com/kubernetes-csi/external-snapshotter/tree/release-4.0) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | k8s.gcr.io/sig-storage/snapshot-controller:v4.0.0 | v1.20 | - | v1.20
 [external-snapshotter v3.0.3 (beta)](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v3.0.3) | [release-3.0](https://github.com/kubernetes-csi/external-snapshotter/tree/release-3.0) | [v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | - | k8s.gcr.io/sig-storage/snapshot-controller:v3.0.3 | v1.17 | - | v1.17
+
 
 ### Unsupported Versions
 


### PR DESCRIPTION
Below sidecars have been udpated to latest versions in the doc
external-attacher   : v3.3.0
external-resizer    : v1.3.0
external-snapshotter: v4.2.1

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>