### PR TITLE
Move CSIVolumeFSGroupPolicy to GA

### DIFF
--- a/book/src/csi-driver-object.md
+++ b/book/src/csi-driver-object.md
@@ -30,7 +30,7 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: true
-  fsGroupPolicy: File # added in Kubernetes 1.19, this field is beta as of Kubernetes 1.20
+  fsGroupPolicy: File # added in Kubernetes 1.19, this field is GA as of Kubernetes 1.23
   volumeLifecycleModes: # added in Kubernetes 1.16, this field is beta
     - Persistent
     - Ephemeral
@@ -61,7 +61,7 @@ These are the important fields:
   - For more information see [Pod Info on Mount](pod-info.md).
 - `fsGroupPolicy`
   - This field was added in Kubernetes 1.19 and cannot be set when using an older Kubernetes release.
-  - This field is beta in Kubernetes 1.20.
+  - This field is beta in Kubernetes 1.20 and GA in Kubernetes 1.23.
   - Controls if this CSI volume driver supports volume ownership and permission changes when volumes are mounted.
   - The following modes are supported, and if not specified the default is `ReadWriteOnceWithFSType`:
     - `None`: Indicates that volumes will be mounted with no modifications, as the CSI volume driver does not support these operations.

--- a/book/src/support-fsgroup.md
+++ b/book/src/support-fsgroup.md
@@ -5,7 +5,8 @@
 Status | Min K8s Version | Max K8s Version 
 --|--|--
 Alpha | 1.19 | 1.19
-Beta | 1.20 | -
+Beta | 1.20 | 1.22
+GA | 1.23 | -
 
 # Overview
 
@@ -47,3 +48,4 @@ To use this field, Kubernetes 1.19 binaries must start with the `CSIVolumeFSGrou
 ```
 --feature-gates=CSIVolumeFSGroupPolicy=true
 ```
+This is enabled by default on 1.20 and higher.


### PR DESCRIPTION
This updates the docs for CSIVolumeFSGroupPolicy to move it from beta to GA in 1.23.

Enhancement: https://github.com/kubernetes/enhancements/issues/1682
Feature gate PR: https://github.com/kubernetes/kubernetes/pull/105940
KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/1682-csi-driver-skip-permission/README.md
Docs: https://kubernetes-csi.github.io/docs/support-fsgroup.html

```release-note
The CSIVolumeFSGroupPolicy feature has moved from beta to GA.
```

/cc @gnufied 