### PR TITLE
Update summary with volume mode conversion doc

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -40,6 +40,7 @@
         - [Token Requests](token-requests.md)
         - [FSGroup Support](support-fsgroup.md)
         - [CSI Windows](csi-windows.md)
+        - [Volume Mode Conversion](prevent-volume-mode-conversion.md)
 - [Deploying a CSI Driver on Kubernetes](deploying.md)
     - [Example](example.md)
 - [Driver Testing](testing-drivers.md)


### PR DESCRIPTION
Adding to the summary so that the documentation shows up on the docs website

Ref - https://github.com/kubernetes-csi/external-provisioner/pull/791#issuecomment-1260938372