### PR TITLE
Reword "master" to "control plane"

### DIFF
--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -26,7 +26,7 @@ Kubernetes users interested in how to use a CSI driver should look at [kubernete
 
 Kubernetes is as minimally prescriptive about packaging and deployment of a CSI Volume Driver as possible.
 
-The only requirements are around how Kubernetes (master and node) components find and communicate with a CSI driver.
+The only requirements are around how Kubernetes (control plane and node) components find and communicate with a CSI driver.
 
 Specifically, the following is dictated by Kubernetes regarding CSI:
 
@@ -35,8 +35,8 @@ Specifically, the following is dictated by Kubernetes regarding CSI:
   * Kubelet discovers CSI drivers (and the Unix Domain Socket to use to interact with a CSI driver) via the [kubelet plugin registration mechanism](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/pluginmanager/pluginwatcher/README.md).
   * Therefore, all CSI drivers deployed on Kubernetes MUST register themselves using the kubelet plugin registration mechanism on each supported node.
 * Master to CSI Driver Communication
-  * Kubernetes master components do not communicate directly (via a Unix Domain Socket or otherwise) with CSI drivers.
-  * Kubernetes master components interact only with the Kubernetes API.
+  * Kubernetes control plane components do not communicate directly (via a Unix Domain Socket or otherwise) with CSI drivers.
+  * Kubernetes control plane components interact only with the Kubernetes API.
   * Therefore, CSI drivers that require operations that depend on the Kubernetes API (like volume create, volume attach, volume snapshot, etc.) MUST watch the Kubernetes API and trigger the appropriate CSI operations against it.
 
 Because these requirements are minimally prescriptive, CSI driver developers are free to implement and deploy their drivers as they see fit.

--- a/book/src/raw-block.md
+++ b/book/src/raw-block.md
@@ -87,7 +87,7 @@ The raw block feature requires the
 ## Kubernetes Cluster Setup
 
 The `BlockVolume` and `CSIBlockVolume` feature gates need to be enabled on
-all Kubernetes masters and nodes.
+the Kubernetes control plane and all nodes.
 
 ```
 --feature-gates=BlockVolume=true,CSIBlockVolume=true...

--- a/book/src/snapshot-restore-feature.md
+++ b/book/src/snapshot-restore-feature.md
@@ -111,7 +111,7 @@ In addition to these new CRD objects, a new, alpha `DataSource` field has been a
 
 ### Kubernetes Cluster Setup
 
-Since volume snapshot is an alpha feature in Kubernetes v1.12 to v1.16, you need to enable a new alpha feature gate called `VolumeSnapshotDataSource` in the Kubernetes master.
+Since volume snapshot is an alpha feature in Kubernetes v1.12 to v1.16, you need to enable a new alpha feature gate called `VolumeSnapshotDataSource` in the Kubernetes control plane.
 
 ```
 --feature-gates=VolumeSnapshotDataSource=true

--- a/book/src/topology.md
+++ b/book/src/topology.md
@@ -55,24 +55,24 @@ Topology feature gate enabled:
 
 ### Beta
 
-In the *Kubernetes cluster* the `CSINodeInfo` feature must be enabled on both Kubernetes master and nodes (refer to the [CSINode Object](csi-node-object.md) section for more info):
+In the *Kubernetes cluster* the `CSINodeInfo` feature must be enabled on both the Kubernetes control plane and nodes (refer to the [CSINode Object](csi-node-object.md) section for more info):
 
 ```
 --feature-gates=CSINodeInfo=true
 ```
 
-In order to fully function properly, all Kubernetes master and nodes must be on at least
+In order to fully function properly, the Kubernetes control plane and all nodes must be on at least
 Kubernetes 1.14. If a selected node is on a lower version, topology is ignored and not
 passed to the driver during `CreateVolume`.
 
 ### Alpha
 
 The alpha feature in the external-provisioner is not compatible across
-Kubernetes versions. In addition, Kubernetes master and node version skew and
+Kubernetes versions. In addition, Kubernetes control plane and node version skew and
 upgrades are not supported.
 
 The `CSINodeInfo`, `VolumeScheduling`, and `KubeletPluginsWatcher` feature gates
-must be enabled on both Kubernetes master and nodes.
+must be enabled on both the Kubernetes control plane and nodes.
 
 The [CSINodeInfo](csi-node-object.md) CRDs also have to be manually installed in the
 cluster.


### PR DESCRIPTION
In most cases this is a direct replacement, but some sections have been slightly changed to reflect if the section is discussing control plane nodes (i.e., nodes that run control plane components) or the control plane components themselves.