### PR TITLE
Update pull.yml to use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -18,7 +18,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
 
       # The same command that users can use locally is used to build documentation.
       - name: Build documentation
@@ -26,7 +26,7 @@ jobs:
       
       # Publish generated site as artifact. Unfortunately viewing it requires
       # downloading a .zip and uncompressing that (https://github.com/actions/upload-artifact/issues/14#issuecomment-620728238)
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: html-docs
           path: docs

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -18,7 +18,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # The same command that users can use locally is used to build documentation.
       - name: Build documentation


### PR DESCRIPTION
this is required, since v1 and v2 are deprecated
see https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/