### PR TITLE
Recommend actual sidecar installation in sample pod

### DIFF
--- a/book/src/deploying.md
+++ b/book/src/deploying.md
@@ -73,7 +73,9 @@ on the host to see mounts created by the CSI driver container. See the example b
         - name: mountpoint-dir
           mountPath: /var/lib/kubelet/pods
           mountPropagation: "Bidirectional"
+      initContainers:
       - name: node-driver-registrar
+        restartPolicy: Always
         ...
         volumeMounts:
         - name: registration-dir


### PR DESCRIPTION
A kubernetes sidecar is an initContainer with restartPolicy:Always. Since we are already calling the helper repositories sidecars, it helps if the example for the user actually installs them as a true sidecar, rather than as a regular container.