### PR TITLE
update PVC annotations secret supported in external-provisioner

### DIFF
--- a/book/src/secrets-and-credentials-storage-class.md
+++ b/book/src/secrets-and-credentials-storage-class.md
@@ -112,6 +112,9 @@ The values of these parameters may be "templates". The `external-provisioner` wi
   * `${pvc.name}`
     * Replaced with the name of the `PersistentVolumeClaim` object that triggered provisioning.
     * Support added in CSI `external-provisioner` v1.2.0+
+  * `${pvc.annotations['<ANNOTATION_KEY>']}` (e.g. `${pvc.annotations['example.com/key']}`)
+    * Replaced with the value of the specified annotation from the `PersistentVolumeClaim` object that triggered provisioning
+    * Support added in CSI `external-provisioner` v5.0.0+
 * `csi.storage.k8s.io/provisioner-secret-namespace`
   * `${pv.name}`
     * Replaced with name of the `PersistentVolume` object being provisioned.


### PR DESCRIPTION
As mentioned in https://github.com/kubernetes-csi/external-provisioner/issues/1148, external-provisioner didn't recognize per per volume secret tokens that reference to PVCs. This was fixed is master branch of external-provisioner. CSI document should be updated to advertise this change to users.

Replaces: #593